### PR TITLE
Add start-up shell script for Linux

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+cd "$(dirname "$0")"
+source ./venv/bin/activate
+pip -V
+python main.py


### PR DESCRIPTION
Adds a basic shell script for activating the venv and starting the API - it requires the user to have already installed the pre-requisites in venv.