### PR TITLE
Adding the usage stat support (prompt_tokens, completion_tokens, and total_tokens)

### DIFF
--- a/OAI/types/chat_completion.py
+++ b/OAI/types/chat_completion.py
@@ -32,8 +32,6 @@ class ChatCompletionResponse(BaseModel):
     created: int = Field(default_factory=lambda: int(time()))
     model: str
     object: str = "chat.completion"
-
-    # TODO: Add usage stats
     usage: Optional[UsageStats] = None
 
 class ChatCompletionStreamChunk(BaseModel):

--- a/OAI/types/common.py
+++ b/OAI/types/common.py
@@ -48,7 +48,7 @@ class CommonCompletionRequest(BaseModel):
     tfs: Optional[float] = 1.0
     repetition_penalty: Optional[float] = 1.0
     repetition_penalty_range: Optional[int] = 0
-    repetition_decay: Optional[int] = 0
+    repetition_slope: Optional[int] = 0
     mirostat_mode: Optional[int] = 0
     mirostat_tau: Optional[float] = 1.5
     mirostat_eta: Optional[float] = 0.1
@@ -85,7 +85,7 @@ class CommonCompletionRequest(BaseModel):
             "tfs": self.tfs,
             "repetition_penalty": self.repetition_penalty,
             "repetition_range": self.repetition_range or self.repetition_penalty_range or -1,
-            "repetition_decay": self.repetition_decay,
+            "repetition_slope": self.repetition_slope,
             "mirostat": self.mirostat_mode == 2,
             "mirostat_tau": self.mirostat_tau,
             "mirostat_eta": self.mirostat_eta,

--- a/OAI/types/common.py
+++ b/OAI/types/common.py
@@ -55,6 +55,11 @@ class CommonCompletionRequest(BaseModel):
     add_bos_token: Optional[bool] = True
     ban_eos_token: Optional[bool] = False
 
+    # Aliased variables
+    # TODO: Add a function to iterate through aliases and return a default value if all are None
+    repetition_range: Optional[int] = None
+    repetition_penalty_range: Optional[int] = None
+
     # Converts to internal generation parameters
     def to_gen_params(self):
         # Convert stop to an array of strings
@@ -79,7 +84,7 @@ class CommonCompletionRequest(BaseModel):
             "min_p": self.min_p,
             "tfs": self.tfs,
             "repetition_penalty": self.repetition_penalty,
-            "repetition_penalty_range": self.repetition_penalty_range,
+            "repetition_range": self.repetition_range or self.repetition_penalty_range or -1,
             "repetition_decay": self.repetition_decay,
             "mirostat": self.mirostat_mode == 2,
             "mirostat_tau": self.mirostat_tau,

--- a/OAI/types/common.py
+++ b/OAI/types/common.py
@@ -8,8 +8,8 @@ class LogProbs(BaseModel):
     top_logprobs: List[Dict[str, float]] = Field(default_factory=list)
 
 class UsageStats(BaseModel):
-    completion_tokens: int
     prompt_tokens: int
+    completion_tokens: int
     total_tokens: int
 
 class CommonCompletionRequest(BaseModel):

--- a/OAI/types/common.py
+++ b/OAI/types/common.py
@@ -48,7 +48,7 @@ class CommonCompletionRequest(BaseModel):
     tfs: Optional[float] = 1.0
     repetition_penalty: Optional[float] = 1.0
     repetition_penalty_range: Optional[int] = 0
-    repetition_slope: Optional[int] = 0
+    repetition_decay: Optional[int] = 0
     mirostat_mode: Optional[int] = 0
     mirostat_tau: Optional[float] = 1.5
     mirostat_eta: Optional[float] = 0.1
@@ -85,7 +85,7 @@ class CommonCompletionRequest(BaseModel):
             "tfs": self.tfs,
             "repetition_penalty": self.repetition_penalty,
             "repetition_range": self.repetition_range or self.repetition_penalty_range or -1,
-            "repetition_slope": self.repetition_slope,
+            "repetition_decay": self.repetition_decay,
             "mirostat": self.mirostat_mode == 2,
             "mirostat_tau": self.mirostat_tau,
             "mirostat_eta": self.mirostat_eta,

--- a/OAI/types/completion.py
+++ b/OAI/types/completion.py
@@ -22,6 +22,4 @@ class CompletionResponse(BaseModel):
     created: int = Field(default_factory=lambda: int(time()))
     model: str
     object: str = "text_completion"
-
-    # TODO: Add usage stats
     usage: Optional[UsageStats] = None

--- a/OAI/utils.py
+++ b/OAI/utils.py
@@ -1,5 +1,5 @@
 import os, pathlib
-from OAI.types.completion import CompletionResponse, CompletionRespChoice
+from OAI.types.completion import CompletionResponse, CompletionRespChoice, UsageStats
 from OAI.types.chat_completion import (
     ChatCompletionMessage,
     ChatCompletionRespChoice,
@@ -20,9 +20,7 @@ try:
 except ImportError:
     _fastchat_available = False
 
-def create_completion_response(text: str, model_name: Optional[str]):
-    # TODO: Add method to get token amounts in model for UsageStats
-
+def create_completion_response(text: str, prompt_tokens: int, completion_tokens: int, model_name: Optional[str]):
     choice = CompletionRespChoice(
         finish_reason = "Generated",
         text = text
@@ -30,14 +28,15 @@ def create_completion_response(text: str, model_name: Optional[str]):
 
     response = CompletionResponse(
         choices = [choice],
-        model = model_name or ""
+        model = model_name or "",
+        usage = UsageStats(prompt_tokens = prompt_tokens,
+                           completion_tokens = completion_tokens,
+                           total_tokens = prompt_tokens + completion_tokens)
     )
 
     return response
 
-def create_chat_completion_response(text: str, model_name: Optional[str]):
-    # TODO: Add method to get token amounts in model for UsageStats
-
+def create_chat_completion_response(text: str, prompt_tokens: int, completion_tokens: int, model_name: Optional[str]):
     message = ChatCompletionMessage(
         role = "assistant",
         content = text
@@ -50,7 +49,10 @@ def create_chat_completion_response(text: str, model_name: Optional[str]):
 
     response = ChatCompletionResponse(
         choices = [choice],
-        model = model_name or ""
+        model = model_name or "",
+        usage = UsageStats(prompt_tokens = prompt_tokens,
+                           completion_tokens = completion_tokens,
+                           total_tokens = prompt_tokens + completion_tokens)
     )
 
     return response

--- a/auth.py
+++ b/auth.py
@@ -31,7 +31,7 @@ auth_keys: Optional[AuthKeys] = None
 def load_auth_keys():
     global auth_keys
     try:
-        with open("api_tokens.yml", "r") as auth_file:
+        with open("api_tokens.yml", "r", encoding = 'utf8') as auth_file:
             auth_keys_dict = yaml.safe_load(auth_file)
             auth_keys = AuthKeys(
                 api_key = auth_keys_dict["api_key"],
@@ -44,7 +44,7 @@ def load_auth_keys():
         )
         auth_keys = new_auth_keys
 
-        with open("api_tokens.yml", "w") as auth_file:
+        with open("api_tokens.yml", "w", encoding = "utf8") as auth_file:
             yaml.safe_dump(vars(auth_keys), auth_file, default_flow_style=False)
 
     print(

--- a/main.py
+++ b/main.py
@@ -229,7 +229,7 @@ if __name__ == "__main__":
 
     # Load from YAML config. Possibly add a config -> kwargs conversion function
     try:
-        with open('config.yml', 'r') as config_file:
+        with open('config.yml', 'r', encoding = "utf8") as config_file:
             config = yaml.safe_load(config_file) or {}
     except Exception as e:
         print(

--- a/model.py
+++ b/model.py
@@ -250,7 +250,7 @@ class ModelContainer:
                 'mirostat_eta' (float) Mirostat eta parameter (default: 0.1)
                 'repetition_penalty' (float): Token repetition/presence penalty (default: 1.15)
                 'repetition_range' (int): Repetition penalty range (default: whole context)
-                'repetition_decay' (int): Repetition penalty range (default: same as range)
+                'repetition_slope' (int): Repetition penalty range (default: same as range)
                 'stop' (List[Union[str, int]]): List of stop strings/tokens to end response (default: [EOS])
                 'max_tokens' (int): Max no. tokens in response (default: 150)
                 'add_bos_token' (bool): Adds the BOS token to the start of the prompt (default: True)
@@ -301,7 +301,11 @@ class ModelContainer:
         gen_settings.mirostat_eta = kwargs.get("mirostat_eta", 0.1)
         gen_settings.token_repetition_penalty = kwargs.get("repetition_penalty", 1.0)
         gen_settings.token_repetition_range = kwargs.get("repetition_range", self.config.max_seq_len)
-        gen_settings.token_repetition_decay = kwargs.get("repetition_decay", gen_settings.token_repetition_range)
+
+        # Always make sure the fallback is 0 if range < 0
+        # It's technically fine to use -1, but this just validates the passed fallback
+        fallback_slope = 0 if gen_settings.token_repetition_penalty <= 0 else gen_settings.token_repetition_range
+        gen_settings.token_repetition_decay = kwargs.get("repetition_slope", fallback_slope or 0)
 
         stop_conditions: List[Union[str, int]] = kwargs.get("stop", [])
         ban_eos_token = kwargs.get("ban_eos_token", False)

--- a/model.py
+++ b/model.py
@@ -250,7 +250,7 @@ class ModelContainer:
                 'mirostat_eta' (float) Mirostat eta parameter (default: 0.1)
                 'repetition_penalty' (float): Token repetition/presence penalty (default: 1.15)
                 'repetition_range' (int): Repetition penalty range (default: whole context)
-                'repetition_slope' (int): Repetition penalty range (default: same as range)
+                'repetition_decay' (int): Repetition penalty range (default: same as range)
                 'stop' (List[Union[str, int]]): List of stop strings/tokens to end response (default: [EOS])
                 'max_tokens' (int): Max no. tokens in response (default: 150)
                 'add_bos_token' (bool): Adds the BOS token to the start of the prompt (default: True)
@@ -302,10 +302,11 @@ class ModelContainer:
         gen_settings.token_repetition_penalty = kwargs.get("repetition_penalty", 1.0)
         gen_settings.token_repetition_range = kwargs.get("repetition_range", self.config.max_seq_len)
 
+
         # Always make sure the fallback is 0 if range < 0
         # It's technically fine to use -1, but this just validates the passed fallback
-        fallback_slope = 0 if gen_settings.token_repetition_penalty <= 0 else gen_settings.token_repetition_range
-        gen_settings.token_repetition_decay = kwargs.get("repetition_slope", fallback_slope or 0)
+        fallback_decay = 0 if gen_settings.token_repetition_penalty <= 0 else gen_settings.token_repetition_range
+        gen_settings.token_repetition_decay = kwargs.get("repetition_decay", fallback_decay or 0)
 
         stop_conditions: List[Union[str, int]] = kwargs.get("stop", [])
         ban_eos_token = kwargs.get("ban_eos_token", False)

--- a/model.py
+++ b/model.py
@@ -226,9 +226,9 @@ class ModelContainer:
 
 
     def generate(self, prompt: str, **kwargs):
-        gen = self.generate_gen(prompt, **kwargs)
-        reponse = "".join(gen)
-        return reponse
+        gen = list(self.generate_gen(prompt, **kwargs))
+        reponse = "".join(map(lambda o: o[0], gen))
+        return reponse, gen[-1][1], gen[-1][2]
 
     def generate_gen(self, prompt: str, **kwargs):
         """
@@ -345,6 +345,8 @@ class ModelContainer:
                 "Generation is truncated and metrics may not be accurate."
             )
 
+        prompt_tokens = ids.shape[-1]
+
         # Begin
 
         generated_tokens = 0
@@ -390,7 +392,7 @@ class ModelContainer:
             elapsed = now - last_chunk_time
 
             if chunk_buffer != "" and (elapsed > stream_interval or eos or generated_tokens == max_tokens):
-                yield chunk_buffer
+                yield chunk_buffer, prompt_tokens, generated_tokens
                 full_response += chunk_buffer
                 chunk_buffer = ""
                 last_chunk_time = now

--- a/model.py
+++ b/model.py
@@ -336,6 +336,13 @@ class ModelContainer:
             add_bos=kwargs.get("add_bos_token", True),
             encode_special_tokens = True
         )
+        context_len = len(ids[0])
+
+        if context_len > self.config.max_seq_len:
+            print(
+                f"WARNING: The context length {context_len} is greater than the max_seq_len {self.config.max_seq_len}.",
+                "Generation is truncated and metrics may not be accurate."
+            )
 
         # Begin
 
@@ -392,14 +399,18 @@ class ModelContainer:
         elapsed_time = last_chunk_time - start_time
 
         initial_response = f"Response: {round(generated_tokens, 2)} tokens generated in {round(elapsed_time, 2)} seconds"
-        extra_responses = []
+        itemization = []
+        extra_parts = []
 
         # Add tokens per second
-        extra_responses.append(f"{'Indeterminate' if elapsed_time == 0 else round(generated_tokens / elapsed_time, 2)} T/s")
+        itemization.append(f"{'Indeterminate' if elapsed_time == 0 else round(generated_tokens / elapsed_time, 2)} T/s")
 
         # Add context (original token count)
         if ids is not None:
-            extra_responses.append(f"context {len(ids[0])} tokens")
+            itemization.append(f"context {context_len} tokens")
+
+        if context_len > self.config.max_seq_len:
+            extra_parts.append("<-- Not accurate (truncated)")
 
         # Print output
-        print(initial_response + " (" + ", ".join(extra_responses) + ")")
+        print(initial_response + " (" + ", ".join(itemization) + ") " + " ".join(extra_parts))

--- a/model.py
+++ b/model.py
@@ -401,7 +401,7 @@ class ModelContainer:
 
         elapsed_time = last_chunk_time - start_time
 
-        initial_response = f"Response: {round(generated_tokens, 2)} tokens generated in {round(elapsed_time, 2)} seconds"
+        initial_response = f"Response: {generated_tokens} tokens generated in {round(elapsed_time, 2)} seconds"
         itemization = []
         extra_parts = []
 

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,29 @@
+import traceback
+from pydantic import BaseModel
+from typing import Optional
+
 # Wrapper callback for load progress
 def load_progress(module, modules):
     yield module, modules
+
+# Common error types
+class TabbyGeneratorErrorMessage(BaseModel):
+    message: str
+    trace: Optional[str] = None
+
+class TabbyGeneratorError(BaseModel):
+    error: TabbyGeneratorErrorMessage
+
+def get_generator_error(exception: Exception):
+    error_message = TabbyGeneratorErrorMessage(
+        message = str(exception),
+        trace = traceback.format_exc()
+    )
+
+    generator_error = TabbyGeneratorError(
+        error = error_message
+    )
+
+    # Log and send the exception
+    print(f"\n{generator_error.error.trace}")
+    return generator_error.json()


### PR DESCRIPTION
Out of the 4 methods of using the API (completion, completion+streaming, chat, chat+streaming), the usage stat was not added to streaming version of the chat. That's because unlike the other 3, this one's response class did not have the usage stat's place holder. So I was not sure if that response is supposed to have it. Adding the support to that response is fairly easy, if needed.