### PR TITLE
Add automatic NTK-aware alpha scaling to model

### DIFF
--- a/model.py
+++ b/model.py
@@ -69,10 +69,17 @@ class ModelContainer:
         self.config = ExLlamaV2Config()
         self.config.model_dir = str(model_directory.resolve())
         self.config.prepare()
+        
+        base_seq_len = self.config.max_seq_len
 
         if "max_seq_len" in kwargs: self.config.max_seq_len = kwargs["max_seq_len"]
         if "rope_scale" in kwargs: self.config.scale_pos_emb = kwargs["rope_scale"]
-        if "rope_alpha" in kwargs: self.config.scale_alpha_value = kwargs["rope_alpha"]
+        if "rope_alpha" in kwargs:
+            self.config.scale_alpha_value = kwargs["rope_alpha"]
+        else:
+            ratio = self.config.max_seq_len / base_seq_len
+            alpha = -0.13436 + 0.80541 * ratio + 0.28833 * ratio ** 2
+            self.config.scale_alpha_value = alpha
         if "no_flash_attn" in kwargs: self.config.no_flash_attn = kwargs["no_flash_attn"]
 
         if "low_mem" in kwargs and kwargs["low_mem"]:
@@ -102,7 +109,7 @@ class ModelContainer:
             self.draft_config.prepare()
 
             if "draft_rope_alpha" in kwargs:
-                self.draft_config.scale_alpha_value = kwargs.get("draft_rope_alpha") or 1
+                self.draft_config.scale_alpha_value = kwargs.get("draft_rope_alpha")
             else:
                 ratio = self.config.max_seq_len / self.draft_config.max_seq_len
                 alpha = -0.13436 + 0.80541 * ratio + 0.28833 * ratio ** 2

--- a/model.py
+++ b/model.py
@@ -79,6 +79,7 @@ class ModelContainer:
         else:
             ratio = self.config.max_seq_len / base_seq_len
             alpha = -0.13436 + 0.80541 * ratio + 0.28833 * ratio ** 2
+            if ratio == 1: alpha = 1.0
             self.config.scale_alpha_value = alpha
         if "no_flash_attn" in kwargs: self.config.no_flash_attn = kwargs["no_flash_attn"]
 
@@ -113,6 +114,7 @@ class ModelContainer:
             else:
                 ratio = self.config.max_seq_len / self.draft_config.max_seq_len
                 alpha = -0.13436 + 0.80541 * ratio + 0.28833 * ratio ** 2
+                if ratio == 1: alpha = 1.0
                 self.draft_config.scale_alpha_value = alpha
 
             self.draft_config.max_seq_len = self.config.max_seq_len            


### PR DESCRIPTION
Enables automatic calculation of NTK-aware alpha scaling for models if the rope_alpha arg is not passed in the config, using the same formula used for draft models. This uses the model's max seq length as defined in config.json and compares it to the configured max sequence length passed to the API (or through config.yml) to determine the ratio used to calculate alpha.

Note: If the model's max seq length and the configured max seq length are the same, the alpha calculated via the existing formula is ~0.96 rather than 1. Open to suggestion on whether we force alpha = 1 in this case.