### PR TITLE
Reverting to use as the gpu_split_auto also evaluates to true

### DIFF
--- a/model.py
+++ b/model.py
@@ -68,7 +68,7 @@ class ModelContainer:
 
         self.cache_fp8 = "cache_mode" in kwargs and kwargs["cache_mode"] == "FP8"
         self.gpu_split = kwargs.get("gpu_split")
-        self.gpu_split_auto = kwargs.get("gpu_split_auto") or True
+        self.gpu_split_auto = kwargs.get("gpu_split_auto", True)
 
         self.config = ExLlamaV2Config()
         self.config.model_dir = str(model_directory.resolve())


### PR DESCRIPTION
It appears that gpu_split_auto always evaluates to True even if set to False due to `or True` defaulting when the gpu_split_auto has been set to False.