### PR TITLE
OAI: adding optional draft model properties for draft_rope alpha and scale

### DIFF
--- a/OAI/types/model.py
+++ b/OAI/types/model.py
@@ -25,8 +25,8 @@ class ModelList(BaseModel):
 
 class DraftModelLoadRequest(BaseModel):
     draft_model_name: str
-    draft_rope_alpha: Optional[float] = 1.0
-    draft_rope_scale: Optional[float] = 1.0
+    draft_rope_alpha: Optional[float] = None
+    draft_rope_scale: Optional[float] = None
 
 # TODO: Unify this with ModelCardParams
 class ModelLoadRequest(BaseModel):

--- a/OAI/types/model.py
+++ b/OAI/types/model.py
@@ -25,8 +25,8 @@ class ModelList(BaseModel):
 
 class DraftModelLoadRequest(BaseModel):
     draft_model_name: str
-    draft_rope_alpha: float = 1.0
-    draft_rope_scale: float = 1.0
+    draft_rope_alpha: Optional[float] = 1.0
+    draft_rope_scale: Optional[float] = 1.0
 
 # TODO: Unify this with ModelCardParams
 class ModelLoadRequest(BaseModel):


### PR DESCRIPTION
When performing a model load request, the draft rope parameters are by default set to 1.0

```
class DraftModelLoadRequest(BaseModel):
    draft_model_name: str
    draft_rope_alpha: float = 1.0
    draft_rope_scale: float = 1.0
```

The problem is that at least in the case of draft model alpha scaling, the draft_rope_alpha can never be None so the draft_rope_alpha is never auto calculated.

```
self.draft_config.scale_pos_emb = unwrap(draft_args.get("draft_rope_scale"), 1.0)
self.draft_config.scale_alpha_value = unwrap(draft_args.get("draft_rope_alpha"), self.calculate_rope_alpha(self.draft_config.max_seq_len))

```

By setting the draft model request parameters as optional then the unwrap can function as intended