### PR TITLE
Add mixtral.jinja template. This has been tested and works quite well…

### DIFF
--- a/templates/mixtral.jinja
+++ b/templates/mixtral.jinja
@@ -1,0 +1,19 @@
+{% for message in messages %}
+  {% if message['role'] == 'user' %}
+    ### Instruction:
+    <s>[INST] {{ message['content']|trim }} [/INST]
+    {% if not loop.last %}
+
+    {% endif %}
+  {% elif message['role'] == 'assistant' %}
+    ### Response:
+    {{ message['content']|trim }}
+    {% if not loop.last %}
+
+    {% endif %}
+  {% endif %}
+{% endfor %}
+{% if add_generation_prompt and messages[-1]['role'] != 'assistant' %}
+    ### Response Placeholder:
+    <s>[INST] [/INST]
+{% endif %}


### PR DESCRIPTION
Enhance the formatting of messages within the mixtral.jinja template file. The primary focus is on making instructions and responses more readable and structured.

Messages are categorized into instructions (user messages) and responses (assistant messages) based on their roles.

Instructions are enclosed within [INST] and [/INST] tags to clearly identify them as user instructions.

Responses are displayed without any additional tags or formatting.

Improved spacing and line breaks for better message separation.