### PR TITLE
Only try to install one of the EXLv2 wheels

### DIFF
--- a/requirements-amd.txt
+++ b/requirements-amd.txt
@@ -3,8 +3,8 @@
 torch
 
 # Exllamav2
-https://github.com/turboderp/exllamav2/releases/download/v0.0.11/exllamav2-0.0.11+rocm5.6-cp311-cp311-linux_x86_64.whl
-https://github.com/turboderp/exllamav2/releases/download/v0.0.11/exllamav2-0.0.11+rocm5.6-cp310-cp310-linux_x86_64.whl
+https://github.com/turboderp/exllamav2/releases/download/v0.0.11/exllamav2-0.0.11+rocm5.6-cp311-cp311-linux_x86_64.whl; python_version == "3.11"
+https://github.com/turboderp/exllamav2/releases/download/v0.0.11/exllamav2-0.0.11+rocm5.6-cp310-cp310-linux_x86_64.whl; python_version == "3.10"
 
 # Pip dependencies
 fastapi


### PR DESCRIPTION
This addresses the following error when using the `requirements-amd.txt` file and Python 3.11:
```
ERROR: exllamav2-0.0.11+rocm5.6-cp310-cp310-linux_x86_64.whl is not a supported wheel on this platform.
```