### PR TITLE
Switch over logprobs to work with post-sampling

### DIFF
--- a/backends/exllamav2/utils.py
+++ b/backends/exllamav2/utils.py
@@ -9,7 +9,7 @@ logger = init_logger(__name__)
 def check_exllama_version():
     """Verifies the exllama version"""
 
-    required_version = version.parse("0.0.13.post1")
+    required_version = version.parse("0.0.13.post2")
     current_version = version.parse(package_version("exllamav2").split("+")[0])
 
     if current_version < required_version:

--- a/requirements-amd.txt
+++ b/requirements-amd.txt
@@ -3,8 +3,8 @@
 torch ~= 2.2
 
 # Exllamav2
-https://github.com/turboderp/exllamav2/releases/download/0.0.13.post1/exllamav2-0.0.13.post1+rocm5.6-cp311-cp311-linux_x86_64.whl; python_version == "3.11"
-https://github.com/turboderp/exllamav2/releases/download/0.0.13.post1/exllamav2-0.0.13.post1+rocm5.6-cp310-cp310-linux_x86_64.whl; python_version == "3.10"
+https://github.com/turboderp/exllamav2/releases/download/0.0.13.post2/exllamav2-0.0.13.post2+rocm5.6-cp311-cp311-linux_x86_64.whl; python_version == "3.11"
+https://github.com/turboderp/exllamav2/releases/download/0.0.13.post2/exllamav2-0.0.13.post2+rocm5.6-cp310-cp310-linux_x86_64.whl; python_version == "3.10"
 
 # Pip dependencies
 fastapi

--- a/requirements-cu118.txt
+++ b/requirements-cu118.txt
@@ -5,12 +5,12 @@ torch ~= 2.2
 # Exllamav2
 
 # Windows
-https://github.com/turboderp/exllamav2/releases/download/0.0.13.post1/exllamav2-0.0.13.post1+cu118-cp311-cp311-win_amd64.whl; platform_system == "Windows" and python_version == "3.11"
-https://github.com/turboderp/exllamav2/releases/download/0.0.13.post1/exllamav2-0.0.13.post1+cu118-cp310-cp310-win_amd64.whl; platform_system == "Windows" and python_version == "3.10"
+https://github.com/turboderp/exllamav2/releases/download/0.0.13.post2/exllamav2-0.0.13.post2+cu118-cp311-cp311-win_amd64.whl; platform_system == "Windows" and python_version == "3.11"
+https://github.com/turboderp/exllamav2/releases/download/0.0.13.post2/exllamav2-0.0.13.post2+cu118-cp310-cp310-win_amd64.whl; platform_system == "Windows" and python_version == "3.10"
 
 # Linux
-https://github.com/turboderp/exllamav2/releases/download/0.0.13.post1/exllamav2-0.0.13.post1+cu118-cp311-cp311-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64" and python_version == "3.11"
-https://github.com/turboderp/exllamav2/releases/download/0.0.13.post1/exllamav2-0.0.13.post1+cu118-cp310-cp310-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64" and python_version == "3.10"
+https://github.com/turboderp/exllamav2/releases/download/0.0.13.post2/exllamav2-0.0.13.post2+cu118-cp311-cp311-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64" and python_version == "3.11"
+https://github.com/turboderp/exllamav2/releases/download/0.0.13.post2/exllamav2-0.0.13.post2+cu118-cp310-cp310-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64" and python_version == "3.10"
 
 # Pip dependencies
 fastapi

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,12 +5,12 @@ torch ~= 2.2
 # Exllamav2
 
 # Windows
-https://github.com/turboderp/exllamav2/releases/download/0.0.13.post1/exllamav2-0.0.13.post1+cu121-cp311-cp311-win_amd64.whl; platform_system == "Windows" and python_version == "3.11"
-https://github.com/turboderp/exllamav2/releases/download/0.0.13.post1/exllamav2-0.0.13.post1+cu121-cp310-cp310-win_amd64.whl; platform_system == "Windows" and python_version == "3.10"
+https://github.com/turboderp/exllamav2/releases/download/0.0.13.post2/exllamav2-0.0.13.post2+cu121-cp311-cp311-win_amd64.whl; platform_system == "Windows" and python_version == "3.11"
+https://github.com/turboderp/exllamav2/releases/download/0.0.13.post2/exllamav2-0.0.13.post2+cu121-cp310-cp310-win_amd64.whl; platform_system == "Windows" and python_version == "3.10"
 
 # Linux
-https://github.com/turboderp/exllamav2/releases/download/0.0.13.post1/exllamav2-0.0.13.post1+cu121-cp311-cp311-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64" and python_version == "3.11"
-https://github.com/turboderp/exllamav2/releases/download/0.0.13.post1/exllamav2-0.0.13.post1+cu121-cp310-cp310-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64" and python_version == "3.10"
+https://github.com/turboderp/exllamav2/releases/download/0.0.13.post2/exllamav2-0.0.13.post2+cu121-cp311-cp311-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64" and python_version == "3.11"
+https://github.com/turboderp/exllamav2/releases/download/0.0.13.post2/exllamav2-0.0.13.post2+cu121-cp310-cp310-linux_x86_64.whl; platform_system == "Linux" and platform_machine == "x86_64" and python_version == "3.10"
 
 # Pip dependencies
 fastapi


### PR DESCRIPTION
**Description**
Change logits to return post-sampling vs pre-sampling to accurately represent the correct percentages.

Also switch the generator to use the streaming_ex gen which returns a more flexible dictionary.

Blocking on release of exllamav2 v0.0.13.post2