### PR TITLE
Additional clarification for override_base_seq_len

### DIFF
--- a/config_sample.yml
+++ b/config_sample.yml
@@ -73,7 +73,8 @@ model:
 
   # Overrides base model context length (default: Empty)
   # WARNING: Don't set this unless you know what you're doing!
-  # Only use this if the model's base sequence length in config.json is incorrect (ex. Mistral/Mixtral models)
+  # Again, do NOT use this for configuring context length, use max_seq_len above ^
+  # Only use this if the model's base sequence length in config.json is incorrect (ex. Mistral 7B)
   #override_base_seq_len:
 
   # Automatically allocate resources to GPUs (default: True)


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
In discussion with multiple users in support threads, new users frequently incorrectly use override_base_seq_len instead of max_seq_len to configure context length. This will cause problems if they attempt to use the built in automatic NTK rope scaling for context extension.

Also the documentation incorrectly specifies Mixtral as an example model with an incorrect base sequence length, when this only applies to Mistral 7B with sliding window attention inactive in exl2.

**Why should this feature be added?**
It will lead to fewer users using incorrect configurations.

**Examples**
None

**Additional context**
None
