### PR TITLE
[FEAT] Add extra concurrency to API

### DIFF
--- a/OAI/types/lora.py
+++ b/OAI/types/lora.py
@@ -32,6 +32,7 @@ class LoraLoadRequest(BaseModel):
     """Represents a Lora load request."""
 
     loras: List[LoraLoadInfo]
+    skip_queue: bool = False
 
 
 class LoraLoadResponse(BaseModel):

--- a/OAI/types/model.py
+++ b/OAI/types/model.py
@@ -93,6 +93,7 @@ class ModelLoadRequest(BaseModel):
     use_cfg: Optional[bool] = None
     fasttensors: Optional[bool] = False
     draft: Optional[DraftModelLoadRequest] = None
+    skip_queue: Optional[bool] = False
 
 
 class ModelLoadResponse(BaseModel):

--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -55,6 +55,7 @@ class ExllamaV2Container:
     autosplit_reserve: List[float] = [96 * 1024**2]
 
     # Load state
+    model_is_loading: bool = False
     model_loaded: bool = False
 
     def __init__(self, model_directory: pathlib.Path, quiet=False, **kwargs):
@@ -350,6 +351,9 @@ class ExllamaV2Container:
                 def progress(loaded_modules: int, total_modules: int)
         """
 
+        # Notify that the model is being loaded
+        self.model_is_loading = True
+
         # Load tokenizer
         self.tokenizer = ExLlamaV2Tokenizer(self.config)
 
@@ -439,6 +443,7 @@ class ExllamaV2Container:
         torch.cuda.empty_cache()
 
         # Update model load state
+        self.model_is_loading = False
         self.model_loaded = True
         logger.info("Model successfully loaded.")
 
@@ -472,7 +477,7 @@ class ExllamaV2Container:
 
         # Update model load state
         self.model_loaded = False
-        logger.info("Model unloaded.")
+        logger.info("Loras unloaded." if loras_only else "Model unloaded.")
 
     def encode_tokens(self, text: str, **kwargs):
         """Wrapper to encode tokens from a text string"""

--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -54,6 +54,9 @@ class ExllamaV2Container:
     gpu_split_auto: bool = True
     autosplit_reserve: List[float] = [96 * 1024**2]
 
+    # Load state
+    model_loaded: bool = False
+
     def __init__(self, model_directory: pathlib.Path, quiet=False, **kwargs):
         """
         Create model container
@@ -435,6 +438,8 @@ class ExllamaV2Container:
         gc.collect()
         torch.cuda.empty_cache()
 
+        # Update model load state
+        self.model_loaded = True
         logger.info("Model successfully loaded.")
 
     def unload(self, loras_only: bool = False):
@@ -465,6 +470,8 @@ class ExllamaV2Container:
         gc.collect()
         torch.cuda.empty_cache()
 
+        # Update model load state
+        self.model_loaded = False
         logger.info("Model unloaded.")
 
     def encode_tokens(self, text: str, **kwargs):

--- a/common/auth.py
+++ b/common/auth.py
@@ -76,7 +76,9 @@ def load_auth_keys(disable_from_config: bool):
     )
 
 
-def check_api_key(x_api_key: str = Header(None), authorization: str = Header(None)):
+async def check_api_key(
+    x_api_key: str = Header(None), authorization: str = Header(None)
+):
     """Check if the API key is valid."""
 
     # Allow request if auth is disabled
@@ -102,7 +104,9 @@ def check_api_key(x_api_key: str = Header(None), authorization: str = Header(Non
     raise HTTPException(401, "Please provide an API key")
 
 
-def check_admin_key(x_admin_key: str = Header(None), authorization: str = Header(None)):
+async def check_admin_key(
+    x_admin_key: str = Header(None), authorization: str = Header(None)
+):
     """Check if the admin key is valid."""
 
     # Allow request if auth is disabled

--- a/common/utils.py
+++ b/common/utils.py
@@ -45,8 +45,10 @@ def handle_request_error(message: str):
     request_error = TabbyRequestError(error=error_message)
 
     # Log the error and provided message to the console
-    logger.error(error_message.trace)
-    logger.error(message)
+    if error_message.trace:
+        logger.error(error_message.trace)
+
+    logger.error(f"Sent to request: {message}")
 
     return request_error
 

--- a/main.py
+++ b/main.py
@@ -136,10 +136,6 @@ async def list_models():
     "/v1/model",
     dependencies=[Depends(check_api_key), Depends(_check_model_container)],
 )
-@app.get(
-    "/v1/internal/model/info",
-    dependencies=[Depends(check_api_key), Depends(_check_model_container)],
-)
 async def get_current_model():
     """Returns the currently loaded model."""
     model_name = MODEL_CONTAINER.get_model_path().name


### PR DESCRIPTION
Fixes a lot of issues with the API in terms of parallel requests and what specifically goes into the "request queue" (aka a semaphore). These commits help preserve the parallelism for single users and make the queueing system for multiple users (e.g 2-5 people).

The new request/semaphore architecture will be like this
- Any load requests are blocked by the semaphore to be processed sequentially
- Any load request can have the `skip_queue` parameter which bypasses the semaphore and immediately executes the request.
- Any unload requests are immediately executed
- All completion requests get placed inside the semaphore

More optimizations are needed in the future for extra cases, but I'd like to do other things to make the API code cleaner beforehand.

This is a good starting point/bugfix for immediately patching the API to run properly rather than blocking and stalling requests.