### PR TITLE
Add Hugging Face repo download endpoint

### DIFF
--- a/OAI/types/download.py
+++ b/OAI/types/download.py
@@ -1,0 +1,12 @@
+""" Downloader types """
+from pydantic import BaseModel
+from typing import Optional
+
+
+class HFDownloadRequest(BaseModel):
+    """Represents a HuggingFace download request."""
+
+    repo_id: str
+    revision: Optional[str] = "main"
+    repo_type: Optional[str] = "model"
+    hf_token: Optional[str] = None

--- a/common/downloaders.py
+++ b/common/downloaders.py
@@ -1,0 +1,23 @@
+from common.logger import init_logger
+
+logger = init_logger(__name__)
+try:
+    from huggingface_hub import snapshot_download
+except ImportError:
+    logger.error(
+        "huggingface_hub not installed, HF downloader endpoint will not be functional."
+    )
+    snapshot_download = None
+
+
+def hf_download(repo_id, revision, path, api_token):
+    if not snapshot_download:
+        logger.error("HF downloader is not available.")
+        return
+    return snapshot_download(
+        repo_id=repo_id,
+        revision=revision,
+        local_dir=path,
+        local_dir_use_symlinks=False,
+        token=api_token,
+    )


### PR DESCRIPTION
Adds a wrapper for huggingface_hub downloader to download models/loras via API request, requires optional dependency huggingface_hub.

TODO:
- [ ] More robust reporting of errors that occur within snapshot_download such as a bad repo_id or revision, unauthorized access to a gated/private repo (currently results in a simple 500 Internal Server Error)
- [ ] Consider addition of default HF token to be used for downloading to config.yml, or reading a saved HF token from HF cache

**Is your pull request related to a problem? Please describe.**
N/A

**Why should this feature be added?**
Some users have requested the ability to download models through tabbyAPI itself. This adds a simple option that requires an optional dependency package for those who want this functionality and do not want to deal directly with huggingface-cli.

**Examples**
N/A

**Additional context**
N/A
