### PR TITLE
Make API more asynchronous

### DIFF
--- a/common/concurrency.py
+++ b/common/concurrency.py
@@ -2,10 +2,38 @@
 
 import asyncio
 import inspect
+from fastapi.concurrency import run_in_threadpool  # noqa
 from functools import partialmethod
 from typing import AsyncGenerator, Generator, Union
 
 generate_semaphore = asyncio.Semaphore(1)
+
+
+# Originally from https://github.com/encode/starlette/blob/master/starlette/concurrency.py
+# Uses generators instead of generics
+class _StopIteration(Exception):
+    """Wrapper for StopIteration because it doesn't send across threads."""
+
+    pass
+
+
+def gen_next(generator: Generator):
+    """Threaded function to get the next value in an iterator."""
+
+    try:
+        return next(generator)
+    except StopIteration as e:
+        raise _StopIteration from e
+
+
+async def iterate_in_threadpool(generator: Generator) -> AsyncGenerator:
+    """Iterates a generator within a threadpool."""
+
+    while True:
+        try:
+            yield await asyncio.to_thread(gen_next, generator)
+        except _StopIteration:
+            break
 
 
 def release_semaphore():
@@ -16,19 +44,18 @@ async def generate_with_semaphore(generator: Union[AsyncGenerator, Generator]):
     """Generate with a semaphore."""
 
     async with generate_semaphore:
-        if inspect.isasyncgenfunction:
-            async for result in generator():
-                yield result
-        else:
-            for result in generator():
-                yield result
+        if not inspect.isasyncgenfunction:
+            generator = iterate_in_threadpool(generator())
+
+        async for result in generator():
+            yield result
 
 
 async def call_with_semaphore(callback: partialmethod):
     """Call with a semaphore."""
 
     async with generate_semaphore:
-        if inspect.iscoroutinefunction(callback):
-            return await callback()
-        else:
-            return callback()
+        if not inspect.iscoroutinefunction:
+            callback = run_in_threadpool(callback)
+
+        return await callback()

--- a/common/concurrency.py
+++ b/common/concurrency.py
@@ -1,4 +1,4 @@
-"""Generator handling"""
+"""Concurrency handling"""
 
 import asyncio
 import inspect

--- a/common/model.py
+++ b/common/model.py
@@ -52,7 +52,7 @@ async def load_model_gen(model_path: pathlib.Path, **kwargs):
     progress.start()
 
     try:
-        for module, modules in load_status:
+        async for module, modules in load_status:
             if module == 0:
                 loading_task = progress.add_task(
                     f"[cyan]Loading {model_type} modules", total=modules
@@ -76,12 +76,12 @@ async def load_model(model_path: pathlib.Path, **kwargs):
         pass
 
 
-def load_loras(lora_dir, **kwargs):
+async def load_loras(lora_dir, **kwargs):
     """Wrapper to load loras."""
     if len(container.active_loras) > 0:
         unload_loras()
 
-    return container.load_loras(lora_dir, **kwargs)
+    return await container.load_loras(lora_dir, **kwargs)
 
 
 def unload_loras():

--- a/common/model.py
+++ b/common/model.py
@@ -33,7 +33,7 @@ async def load_model_gen(model_path: pathlib.Path, **kwargs):
     if container and container.model:
         loaded_model_name = container.get_model_path().name
 
-        if loaded_model_name == model_path.name:
+        if loaded_model_name == model_path.name and container.model_loaded:
             raise ValueError(
                 f'Model "{loaded_model_name}" is already loaded! Aborting.'
             )

--- a/common/model.py
+++ b/common/model.py
@@ -72,7 +72,7 @@ async def load_model_gen(model_path: pathlib.Path, **kwargs):
 
 
 async def load_model(model_path: pathlib.Path, **kwargs):
-    async for _, _, _ in load_model_gen(model_path, **kwargs):
+    async for _ in load_model_gen(model_path, **kwargs):
         pass
 
 

--- a/common/signals.py
+++ b/common/signals.py
@@ -1,0 +1,23 @@
+import signal
+import sys
+from loguru import logger
+from types import FrameType
+
+
+def signal_handler(*_):
+    """Signal handler for main function. Run before uvicorn starts."""
+
+    logger.warning("Shutdown signal called. Exiting gracefully.")
+    sys.exit(0)
+
+
+def uvicorn_signal_handler(signal_event: signal.Signals):
+    """Overrides uvicorn's signal handler."""
+
+    default_signal_handler = signal.getsignal(signal_event)
+
+    def wrapped_handler(signum: int, frame: FrameType = None):
+        logger.warning("Shutdown signal called. Exiting gracefully.")
+        default_signal_handler(signum, frame)
+
+    signal.signal(signal_event, wrapped_handler)

--- a/common/utils.py
+++ b/common/utils.py
@@ -6,6 +6,8 @@ from loguru import logger
 from pydantic import BaseModel
 from typing import Optional
 
+from common.concurrency import release_semaphore
+
 
 def load_progress(module, modules):
     """Wrapper callback for load progress."""
@@ -49,6 +51,13 @@ def handle_request_error(message: str, exc_info: bool = True):
     logger.error(f"Sent to request: {message}")
 
     return request_error
+
+
+def handle_request_disconnect(message: str):
+    """Wrapper for handling for request disconnection."""
+
+    release_semaphore()
+    logger.error(message)
 
 
 def unwrap(wrapped, default=None):

--- a/endpoints/OAI/utils/completion.py
+++ b/endpoints/OAI/utils/completion.py
@@ -1,7 +1,7 @@
 """Completion utilities for OAI server."""
 
-from asyncio import CancelledError
 import pathlib
+from asyncio import CancelledError
 from fastapi import HTTPException
 from typing import Optional
 

--- a/endpoints/OAI/utils/lora.py
+++ b/endpoints/OAI/utils/lora.py
@@ -9,6 +9,6 @@ def get_lora_list(lora_path: pathlib.Path):
     for path in lora_path.iterdir():
         if path.is_dir():
             lora_card = LoraCard(id=path.name)
-            lora_list.data.append(lora_card)  # pylint: disable=no-member
+            lora_list.data.append(lora_card)
 
     return lora_list

--- a/main.py
+++ b/main.py
@@ -5,9 +5,6 @@ import os
 import pathlib
 import signal
 import sys
-import threading
-import time
-from functools import partial
 from loguru import logger
 from typing import Optional
 
@@ -121,13 +118,7 @@ async def entrypoint(args: Optional[dict] = None):
             lora_dir = pathlib.Path(unwrap(lora_config.get("lora_dir"), "loras"))
             model.container.load_loras(lora_dir.resolve(), **lora_config)
 
-    # TODO: Replace this with abortables, async via producer consumer, or something else
-    api_thread = threading.Thread(target=partial(start_api, host, port), daemon=True)
-
-    api_thread.start()
-    # Keep the program alive
-    while api_thread.is_alive():
-        time.sleep(0.5)
+    await start_api(host, port)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -4,7 +4,6 @@ import asyncio
 import os
 import pathlib
 import signal
-import sys
 from loguru import logger
 from typing import Optional
 
@@ -13,13 +12,9 @@ from common import config, gen_logging, sampling, model
 from common.args import convert_args_to_dict, init_argparser
 from common.auth import load_auth_keys
 from common.logger import setup_logger
+from common.signals import signal_handler
 from common.utils import is_port_in_use, unwrap
 from endpoints.OAI.app import start_api
-
-
-def signal_handler(*_):
-    logger.warning("Shutdown signal called. Exiting gracefully.")
-    sys.exit(0)
 
 
 async def entrypoint(args: Optional[dict] = None):


### PR DESCRIPTION
Previously, the API used a lot of thread hacks to work properly. This involved spawning the API itself on a separate thread which is extremely unideal. Instead, opt for an async first approach and add synchronous workflows as needed.

This change adopts exllamav2's synchronous nature with tabby's async-first principle, allowing for the ability to implement task-based calls in the future which are also easily cancellable. In addition, fix a few more API problems involving loading and signal handling.

This change is probably the closest to async that I can get without rewriting exllamav2 itself or making a full async wrapper. There are still threads being used here, but it's used in a more conventional method of "running stuff in the background" rather than "running the event loop inside a separate thread".