### PR TITLE
Add support for min_tokens and banned_strings

### DIFF
--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -929,24 +929,9 @@ class ExllamaV2Container:
                 }
             )
 
-        # Check if decode_special_tokens is supported
-        # TODO: Remove when a new version of ExllamaV2 is released
-        if decode_special_tokens:
-            begin_stream_signature = signature(self.generator.begin_stream_ex)
-
-            try:
-                _bound_vars = begin_stream_signature.bind_partial(
-                    decode_special_tokens=True
-                )
-                begin_stream_args["decode_special_tokens"] = decode_special_tokens
-            except TypeError:
-                logger.warning(
-                    "skip_special_tokens is not supported by the currently "
-                    "installed ExLlamaV2 version."
-                )
+        # MARK: Function signature checks. Not needed in newer ExllamaV2 versions
 
         # Check if temporary token bans are supported
-        # TODO: Remove when a new version of ExllamaV2 is released
         if min_tokens:
             stream_signature = signature(self.generator.stream_ex)
 
@@ -962,7 +947,6 @@ class ExllamaV2Container:
                 min_tokens = 0
 
         # Check if banned_strings is supported
-        # TODO: Remove when a new version of ExllamaV2 is released
         if banned_strings:
             begin_stream_signature = signature(self.generator.begin_stream_ex)
 
@@ -976,6 +960,7 @@ class ExllamaV2Container:
                     "banned_strings is not supported by the currently "
                     "installed ExLlamaV2 version."
                 )
+                banned_strings = []
 
         # Log generation options to console
         # Some options are too large, so log the args instead

--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -791,6 +791,7 @@ class ExllamaV2Container:
         )
 
         stop_conditions: List[Union[str, int]] = unwrap(kwargs.get("stop"), [])
+        banned_strings: List[str] = unwrap(kwargs.get("banned_strings"), [])
         add_bos_token = unwrap(kwargs.get("add_bos_token"), True)
         ban_eos_token = unwrap(kwargs.get("ban_eos_token"), False)
         logit_bias = kwargs.get("logit_bias")
@@ -960,6 +961,22 @@ class ExllamaV2Container:
                 )
                 min_tokens = 0
 
+        # Check if banned_strings is supported
+        # TODO: Remove when a new version of ExllamaV2 is released
+        if banned_strings:
+            begin_stream_signature = signature(self.generator.begin_stream_ex)
+
+            try:
+                _bound_vars = begin_stream_signature.bind_partial(
+                    banned_strings=[]
+                )
+                begin_stream_args["banned_strings"] = banned_strings
+            except TypeError:
+                logger.warning(
+                    "banned_strings is not supported by the currently "
+                    "installed ExLlamaV2 version."
+                )
+
         # Log generation options to console
         # Some options are too large, so log the args instead
         log_generation_params(
@@ -979,6 +996,7 @@ class ExllamaV2Container:
             logprobs=request_logprobs,
             stop_conditions=stop_conditions,
             banned_tokens=banned_tokens,
+            banned_strings=banned_strings,
             logit_bias=logit_bias,
         )
 

--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -936,9 +936,7 @@ class ExllamaV2Container:
             stream_signature = signature(self.generator.stream_ex)
 
             try:
-                _bound_vars = stream_signature.bind_partial(
-                    ban_tokens=[]
-                )
+                _bound_vars = stream_signature.bind_partial(ban_tokens=[])
             except TypeError:
                 logger.warning(
                     "min_tokens is not supported by the currently "
@@ -951,9 +949,7 @@ class ExllamaV2Container:
             begin_stream_signature = signature(self.generator.begin_stream_ex)
 
             try:
-                _bound_vars = begin_stream_signature.bind_partial(
-                    banned_strings=[]
-                )
+                _bound_vars = begin_stream_signature.bind_partial(banned_strings=[])
                 begin_stream_args["banned_strings"] = banned_strings
             except TypeError:
                 logger.warning(

--- a/common/sampling.py
+++ b/common/sampling.py
@@ -32,6 +32,10 @@ class BaseSamplerRequest(BaseModel):
         default_factory=lambda: get_default_sampler_value("stop", [])
     )
 
+    banned_strings: Optional[Union[str, List[str]]] = Field(
+        default_factory=lambda: get_default_sampler_value("banned_strings", [])
+    )
+
     token_healing: Optional[bool] = Field(
         default_factory=lambda: get_default_sampler_value("token_healing", False)
     )
@@ -257,6 +261,10 @@ class BaseSamplerRequest(BaseModel):
         if self.stop and isinstance(self.stop, str):
             self.stop = [self.stop]
 
+        # Convert banned_strings to an array of strings
+        if self.banned_strings and isinstance(self.banned_strings, str):
+            self.banned_strings = [self.banned_strings]
+
         # Convert string banned tokens to an integer list
         if self.banned_tokens and isinstance(self.banned_tokens, str):
             self.banned_tokens = [
@@ -268,6 +276,7 @@ class BaseSamplerRequest(BaseModel):
             "min_tokens": self.min_tokens,
             "generate_window": self.generate_window,
             "stop": self.stop,
+            "banned_strings": self.banned_strings,
             "add_bos_token": self.add_bos_token,
             "ban_eos_token": self.ban_eos_token,
             "skip_special_tokens": self.skip_special_tokens,

--- a/common/sampling.py
+++ b/common/sampling.py
@@ -18,6 +18,11 @@ class BaseSamplerRequest(BaseModel):
         examples=[150],
     )
 
+    min_tokens: Optional[int] = Field(
+        default_factory=lambda: get_default_sampler_value("min_tokens", 0),
+        examples=[0],
+    )
+
     generate_window: Optional[int] = Field(
         default_factory=lambda: get_default_sampler_value("generate_window"),
         examples=[512],
@@ -260,6 +265,7 @@ class BaseSamplerRequest(BaseModel):
 
         gen_params = {
             "max_tokens": self.max_tokens,
+            "min_tokens": self.min_tokens,
             "generate_window": self.generate_window,
             "stop": self.stop,
             "add_bos_token": self.add_bos_token,

--- a/sampler_overrides/sample_preset.yml
+++ b/sampler_overrides/sample_preset.yml
@@ -11,6 +11,9 @@
 max_tokens:
   override: 150
   force: false
+min_tokens:
+  override: 0
+  force: false
 stop:
   override: []
   force: false

--- a/sampler_overrides/sample_preset.yml
+++ b/sampler_overrides/sample_preset.yml
@@ -18,6 +18,10 @@ stop:
   override: []
   force: false
   additive: false
+banned_strings:
+  override: []
+  force: false
+  additive: false
 token_healing:
   override: false
   force: false


### PR DESCRIPTION
`min_tokens`:
Bans the EOS token until the generation reaches a minimum length. This will not prevent the model from otherwise ending the generation early by outputting other stop conditions.

I did not add validation for this arg because improper values for `min_tokens` should not cause any errors or aberrant behavior. Negative values will function the same as zero, and values greater than `max_tokens` will function as a full EOS ban.

`banned_strings`:
From exllamav2: List of strings that the generator will refuse to output. As soon as a partial match happens, a checkpoint is saved that the generator can rewind to if need be. Subsequent tokens are then held until the full string is resolved (match or no match) and either emitted or discarded, accordingly.

Both require exllamav2 dev with the new features added. Adds a check for these features until the next release of exllamav2.

**Is your pull request related to a problem? Please describe.**
Users may want to enforce a minimum length on generations before EOS is generated. In the case of llama 3 instruct, sometimes the model responds with an early EOT/EOS token when it's pushed into a situation where it doesn't know what to do.

Users may also want to disallow certain phrases or n-grams that they find particularly bothersome, such as "As an AI", etc. This would allow these sequences to be banned.

**Why should this feature be added?**
It would allow users to enforce a minimum length on generations before EOS is generated, and to ban specific strings from being generated.

**Examples**
N/A

**Additional context**
N/A
