### PR TITLE
Fix: Actually pass banned_strings to the generation call.

### DIFF
--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -920,7 +920,7 @@ class ExllamaV2Container:
             "return_logits": request_logprobs > 0,
             "abort_event": abort_event,
             "banned_strings": banned_strings,
-            "decode_special_tokens", decode_special_tokens,
+            "decode_special_tokens": decode_special_tokens,
         }
 
         if self.use_cfg:

--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -919,6 +919,7 @@ class ExllamaV2Container:
             "return_top_tokens": request_logprobs,
             "return_logits": request_logprobs > 0,
             "abort_event": abort_event,
+            "banned_strings": banned_strings,
         }
 
         if self.use_cfg:

--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -920,6 +920,7 @@ class ExllamaV2Container:
             "return_logits": request_logprobs > 0,
             "abort_event": abort_event,
             "banned_strings": banned_strings,
+            "decode_special_tokens", decode_special_tokens,
         }
 
         if self.use_cfg:


### PR DESCRIPTION
`banned_strings` is never added to `begin_stream_args`, so it's never passed into the `begin_stream_ex` call, and thus doesn't do anything.

This PR just adds it in.

Edit: `decode_special_tokens` was missing as well