### PR TITLE
[fix] example config for lora weight is invalid

### DIFF
--- a/config_sample.yml
+++ b/config_sample.yml
@@ -156,4 +156,4 @@ model:
     # List of loras to load and associated scaling factors (default: 1.0). Comment out unused entries or add more rows as needed.
     #loras:
     #- name: lora1
-    #  scaling: 1.0
+    #- scaling: 1.0


### PR DESCRIPTION
in theory yaml does allow multi line index pass-through, but I don't think that was intended as it throws:

```
ERROR:    The YAML config couldn't load because of the following error: 
ERROR:    
ERROR:    while parsing a block collection
ERROR:      in "xxxtabbyAPI/config.yml", line 155, column 7
ERROR:    expected \<block end>, but found '?'
ERROR:      in "xxxtabbyAPI/config.yml", line 156, column 7
ERROR:    
ERROR:    TabbyAPI will start anyway and not parse this config file.
```