### PR TITLE
Add support for specifying k/v cache size

### DIFF
--- a/common/args.py
+++ b/common/args.py
@@ -83,6 +83,11 @@ def add_model_args(parser: argparse.ArgumentParser):
         help="Overrides base model context length",
     )
     model_group.add_argument(
+        "--cache-size",
+        type=int,
+        help="The size of the prompt cache (in number of tokens) to allocate"
+    )
+    model_group.add_argument(
         "--rope-scale", type=float, help="Sets rope_scale or compress_pos_emb"
     )
     model_group.add_argument("--rope-alpha", type=float, help="Sets rope_alpha for NTK")

--- a/common/args.py
+++ b/common/args.py
@@ -85,7 +85,7 @@ def add_model_args(parser: argparse.ArgumentParser):
     model_group.add_argument(
         "--cache-size",
         type=int,
-        help="The size of the prompt cache (in number of tokens) to allocate"
+        help="The size of the prompt cache (in number of tokens) to allocate",
     )
     model_group.add_argument(
         "--rope-scale", type=float, help="Sets rope_scale or compress_pos_emb"

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -77,6 +77,12 @@ model:
   # Only use this if the model's base sequence length in config.json is incorrect (ex. Mistral 7B)
   #override_base_seq_len:
 
+  # Size of the prompt cache to allocate (in number of tokens, must be a multiple of 256)
+  # Larger cache uses more VRAM, but allows for more prompts to be cached and a larger batch of gens to proceed simultanously
+  # The minimum size is max_seq_len, but we recommend setting this to the highest value that will fit on your GPU
+  # Recommend setting this to at least max_seq_len * 2 if you want to use CFG with full-length positive and negative prompts
+  #cache_size:
+
   # Automatically allocate resources to GPUs (default: True)
   # NOTE: Not parsed for single GPU users
   #gpu_split_auto: True

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -77,12 +77,6 @@ model:
   # Only use this if the model's base sequence length in config.json is incorrect (ex. Mistral 7B)
   #override_base_seq_len:
 
-  # Size of the prompt cache to allocate (in number of tokens, must be a multiple of 256)
-  # Larger cache uses more VRAM, but allows for more prompts to be cached and a larger batch of gens to proceed simultanously
-  # The minimum size is max_seq_len, but we recommend setting this to the highest value that will fit on your GPU
-  # Recommend setting this to at least max_seq_len * 2 if you want to use CFG with full-length positive and negative prompts
-  #cache_size:
-
   # Automatically allocate resources to GPUs (default: True)
   # NOTE: Not parsed for single GPU users
   #gpu_split_auto: True
@@ -109,6 +103,12 @@ model:
   # Enable different cache modes for VRAM savings (slight performance hit).
   # Possible values FP16, FP8, Q4. (default: FP16)
   #cache_mode: FP16
+
+  # Size of the prompt cache to allocate (default: max_seq_len)
+  # This must be a multiple of 256. A larger cache uses more VRAM, but allows for more prompts to be processed at once.
+  # NOTE: Cache size should not be less than max_seq_len.
+  # For CFG, set this to 2 * max_seq_len to make room for both positive and negative prompts.
+  #cache_size:
 
   # Chunk size for prompt ingestion. A lower value reduces VRAM usage at the cost of ingestion speed (default: 2048)
   # NOTE: Effects vary depending on the model. An ideal value is between 512 and 4096

--- a/endpoints/OAI/types/model.py
+++ b/endpoints/OAI/types/model.py
@@ -15,6 +15,7 @@ class ModelCardParameters(BaseModel):
     max_seq_len: Optional[int] = None
     rope_scale: Optional[float] = 1.0
     rope_alpha: Optional[float] = 1.0
+    cache_size: Optional[int] = None
     cache_mode: Optional[str] = "FP16"
     chunk_size: Optional[int] = 2048
     prompt_template: Optional[str] = None
@@ -68,6 +69,13 @@ class ModelLoadRequest(BaseModel):
     override_base_seq_len: Optional[int] = Field(
         description=(
             "Overrides the model's base sequence length. " "Leave blank if unsure"
+        ),
+        default=None,
+        examples=[4096],
+    )
+    cache_size: Optional[int] = Field(
+        description=(
+            "Number in tokens, must be greater than or equal to max_seq_len"
         ),
         default=None,
         examples=[4096],

--- a/endpoints/OAI/types/model.py
+++ b/endpoints/OAI/types/model.py
@@ -74,9 +74,7 @@ class ModelLoadRequest(BaseModel):
         examples=[4096],
     )
     cache_size: Optional[int] = Field(
-        description=(
-            "Number in tokens, must be greater than or equal to max_seq_len"
-        ),
+        description=("Number in tokens, must be greater than or equal to max_seq_len"),
         default=None,
         examples=[4096],
     )


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
In order to use CFG at full context length, the user needs to be able to specify a k/v cache size greater than `max_seq_len`.

**Why should this feature be added?**
In order to use CFG at full context length, the user needs to be able to specify a k/v cache size greater than `max_seq_len`. This also allows the user to make full use of their available VRAM for increasing batch size or increasing the number of cached prompts.

**Examples**
N/A

**Additional context**
N/A
