### PR TITLE
Separate new prompt tokens from those reused from cache in metric logging

### DIFF
--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -1125,6 +1125,7 @@ class ExllamaV2Container:
                         log_metrics(
                             result.get("time_enqueued"),
                             result.get("prompt_tokens"),
+                            result.get("cached_tokens"),
                             result.get("time_prefill"),
                             result.get("new_tokens"),
                             result.get("time_generate"),

--- a/common/gen_logging.py
+++ b/common/gen_logging.py
@@ -72,6 +72,7 @@ def log_response(response: str):
 def log_metrics(
     queue_time: float,
     prompt_tokens: int,
+    cached_tokens: int,
     prompt_time: float,
     generated_tokens: int,
     generate_time: float,
@@ -88,9 +89,13 @@ def log_metrics(
     itemization.append(f"Queue: {round(queue_time, 2)} s")
 
     prompt_ts = (
-        "Indeterminate" if prompt_time == 0 else round(prompt_tokens / prompt_time, 2)
+        "Indeterminate"
+        if prompt_time == 0
+        else round((prompt_tokens - cached_tokens) / prompt_time, 2)
     )
-    itemization.append(f"Process: {prompt_ts} T/s")
+    itemization.append(
+        f"Process: {cached_tokens} cached tokens and {prompt_tokens - cached_tokens} new tokens at {prompt_ts} T/s"
+    )
 
     generate_ts = (
         "Indeterminate"

--- a/common/gen_logging.py
+++ b/common/gen_logging.py
@@ -94,7 +94,8 @@ def log_metrics(
         else round((prompt_tokens - cached_tokens) / prompt_time, 2)
     )
     itemization.append(
-        f"Process: {cached_tokens} cached tokens and {prompt_tokens - cached_tokens} new tokens at {prompt_ts} T/s"
+        f"Process: {cached_tokens} cached tokens and "
+        f"{prompt_tokens - cached_tokens} new tokens at {prompt_ts} T/s"
     )
 
     generate_ts = (


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
The prompt processing metrics currently do not take into account how many tokens of the prompt are being reused from cache versus having to be newly processed, leading to misleadingly large numbers when a majority if the prompt is already cached.

**Why should this feature be added?**
This provides more detail regarding how many tokens are reused from cache for each generation, and measures prompt processing speed only on new prompt tokens.

**Examples**
N/A

**Additional context**
The metrics displayed will not be correct until https://github.com/turboderp/exllamav2/commit/ff79b73e82aeb5623214620758fedb42eebb59e9 is merged to exllamav2 master.

Prompt processing T/s may also not be very accurate when there is a small number of new tokens being processed.
