### PR TITLE
Fixed docker-compose.yml bind mounts

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,7 +12,9 @@ services:
       - NAME=TabbyAPI
       - NVIDIA_VISIBLE_DEVICES=all
     volumes:
-      - ./models:/usr/src/app/models
+      - ./models:/app/models
+# Example bind mount to allow for a easily editable config from the host
+#      - ../config.yml:/app/config.yml 
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
Updated the models bind mount and added a example one for a config.yml mount

**Is your pull request related to a problem? Please describe.**
Currently if you spin up a docker deployment via the docker-compose it bind mounts ./models to /usr/src/app/models when the containers working directory is /app not /usr/src/app

**Why should this feature be added?**
This allows for users to spin up the container without issues and gives them a example of how they can expand it.
