### PR TITLE
More extensive checks for paged mode support

### DIFF
--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -237,7 +237,10 @@ class ExllamaV2Container:
         else:
             try:
                 import flash_attn
-                flash_attn_ver = [int(t) for t in flash_attn.__version__.split(".") if t.isdigit()]
+
+                flash_attn_ver = [
+                    int(t) for t in flash_attn.__version__.split(".") if t.isdigit()
+                ]
 
                 # Disable paged mode if the user's flash attention version < 2.5.7
                 if flash_attn_ver < [2, 5, 7]:

--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -254,7 +254,7 @@ class ExllamaV2Container:
                     self.paged = False
                     self.max_batch_size = 1
                 else:
-                    # Disable paged mode if the user's min GPU isn't supported (ampere and up)
+                    # Disable paged mode if the user's min GPU isn't supported (ampere+)
                     min_compute_capability = min(
                         torch.cuda.get_device_capability(device=device_idx)[0]
                         for device_idx in gpu_device_list


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
Multiple users have encountered errors when Tabby attempts to enable paged mode, but some part of their configuration doesn't support it, as Tabby currently only checks for whether the user's GPUs have the compute capability to run flash attention 2.

**Why should this feature be added?**
This PR performs the following checks in order:

1. Disable paged mode if the user passes `no_flash_attention = True`
2. Disable paged mode and flash attention if any of the user's in-use GPUs does not have compute capability for flash attention 2
3. Disable paged mode and flash attention if flash attention is not installed, and instruct user to install
4. Disable paged mode if flash attention version < 2.5.7, and instruct user to update

**Examples**
N/A

**Additional context**
Resolves https://github.com/theroyallab/tabbyAPI/issues/120
