### PR TITLE
Support List type in `messages.content`

### DIFF
--- a/endpoints/OAI/types/chat_completion.py
+++ b/endpoints/OAI/types/chat_completion.py
@@ -41,7 +41,8 @@ class ChatCompletionStreamChoice(BaseModel):
 class ChatCompletionRequest(CommonCompletionRequest):
     # Messages
     # Take in a string as well even though it's not part of the OAI spec
-    messages: Union[str, List[Dict[str, str]]]
+    # support messages.content as a list of dict
+    messages: Union[str, List[Dict[str, Union[str, List[Dict[str, str]]]]]]
     prompt_template: Optional[str] = None
     add_generation_prompt: Optional[bool] = True
     template_vars: Optional[dict] = {}

--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -151,6 +151,19 @@ def format_prompt_with_template(data: ChatCompletionRequest):
             unwrap(data.ban_eos_token, False),
         )
 
+        # Deal with list in messages.content
+        # Just replace the content list with the very first text message
+        for message in data.messages:
+            if message["role"] == "user" and isinstance(message["content"], list):
+                message["content"] = next(
+                    (
+                        content["text"]
+                        for content in message["content"]
+                        if content["type"] == "text"
+                    ),
+                    "",
+                )
+
         # Overwrite any protected vars with their values
         data.template_vars.update(
             {


### PR DESCRIPTION
## Is your pull request related to a problem? Please describe.

This PR is related to [issue116](https://github.com/theroyallab/tabbyAPI/issues/116), [issue117](https://github.com/theroyallab/tabbyAPI/issues/117) and [QChatGPT/issue798](https://github.com/RockChinQ/QChatGPT/issues/798).

OAI API now supports following two kinds of `messages.*.content` in `ChatCompletionRequest`, as the [reference doc](
https://platform.openai.com/docs/api-reference/chat/create)

## Why should this feature be added?

OAI official API supports this case, and some client will not convert the text-only array to a string automatically.

As OpenAI API reference develops, more and more GPT related apps will follow the new API standard. And at that time, tabbyAPI would be outdated.

## Examples

In the given context below:

```json
{
    "model": "gpt-3.5-turbo",
    "messages": [
        {
            "role": "system",
            "content": "You are a helpful assistant."
        },
        {
            "role": "user",
            "content": [
                {
                    "type": "text",
                    "text": "hello"
                }
            ]
        },
        {
            "role": "assistant",
            "content": "hello"
        },
        {
            "role": "user",
            "content": [
                {
                    "type": "text",
                    "text": "who are you?"
                },
                {
                    "type": "image",
                    "image": ""
                }
            ]
        }
    ]
}
```

The former version of tabbyAPI simply fails to generate a response, which is a frustration to those who use certain llm apps and tabbyAPI

However, the new version is able to work, the generated response is shown below:

```json
{
    "id": "chatcmpl-59d2458bc3e84b4a9d62842a384128c5",
    "choices": [
        {
            "index": 0,
            "finish_reason": "stop",
            "message": {
                "role": "assistant",
                "content": "Nice to meet you! I'm a helpful assistant, here to provide information and assist with any questions or topics you'd like to discuss. I'm a text-based AI assistant, and I don't have a personal identity, but I'm designed to be friendly and informative. I can help with a wide range of topics, from answering questions to providing definitions, explaining concepts, generating ideas, and even just having a conversation. What's on your mind today?"
            },
            "logprobs": null
        }
    ],
    "created": 1717227571,
    "model": "llama3-free-70b",
    "object": "chat.completion",
    "usage": {
        "prompt_tokens": 37,
        "completion_tokens": 92,
        "total_tokens": 129
    }
}
```

## Additional context

Support of list in `messages.content` could be necessary. My implementation is rather simple, it would be better to refactor the whole prompt formatter if you want to add multimodal support for tabbyAPI
