### PR TITLE
[fix] Forward exceptions from _stream_collector to stream_generate_(chat)_c…

### DIFF
--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -211,14 +211,17 @@ async def _stream_collector(
 ):
     """Collects a stream and places results in a common queue"""
 
-    new_generation = model.container.generate_gen(prompt, abort_event, **kwargs)
-    async for generation in new_generation:
-        generation["index"] = task_idx
+    try:
+        new_generation = model.container.generate_gen(prompt, abort_event, **kwargs)
+        async for generation in new_generation:
+            generation["index"] = task_idx
 
-        await gen_queue.put(generation)
+            await gen_queue.put(generation)
 
-        if "finish_reason" in generation:
-            break
+            if "finish_reason" in generation:
+                break
+    except Exception as e:
+        await gen_queue.put(e)
 
 
 async def stream_generate_chat_completion(
@@ -253,6 +256,11 @@ async def stream_generate_chat_completion(
                 handle_request_disconnect("Completion generation cancelled by user.")
 
             generation = await gen_queue.get()
+
+            # Stream collector will push an exception to the queue if it fails
+            if isinstance(generation, Exception):
+                raise generation
+
             response = _create_stream_chunk(const_id, generation, model_path.name)
             yield response.model_dump_json()
 

--- a/endpoints/OAI/utils/completion.py
+++ b/endpoints/OAI/utils/completion.py
@@ -82,14 +82,17 @@ async def _stream_collector(
 ):
     """Collects a stream and places results in a common queue"""
 
-    new_generation = model.container.generate_gen(prompt, abort_event, **kwargs)
-    async for generation in new_generation:
-        generation["index"] = task_idx
+    try:
+        new_generation = model.container.generate_gen(prompt, abort_event, **kwargs)
+        async for generation in new_generation:
+            generation["index"] = task_idx
 
-        await gen_queue.put(generation)
+            await gen_queue.put(generation)
 
-        if "finish_reason" in generation:
-            break
+            if "finish_reason" in generation:
+                break
+    except Exception as e:
+        await gen_queue.put(e)
 
 
 async def stream_generate_completion(
@@ -126,6 +129,11 @@ async def stream_generate_completion(
                 handle_request_disconnect("Completion generation cancelled by user.")
 
             generation = await gen_queue.get()
+
+            # Stream collector will push an exception to the queue if it fails
+            if isinstance(generation, Exception):
+                raise generation
+
             response = _create_response(generation, model_path.name)
             yield response.model_dump_json()
 


### PR DESCRIPTION
…ompletion

**Is your pull request related to a problem? Please describe.**
Currently, exceptions raised by the model, generator or model container can't propagate to the completion task since all communication is via a queue. If such an exception is raised, _stream_collector exits and the completion task hangs waiting on the queue (or until canceled by the client.)

**Why should this feature be added?**
The fix catches exceptions in _stream_collector and pushes them to the queue so they can be re-raised by the consumer.

**Examples**
N/A

**Additional context**
N/A
