### PR TITLE
[fix] Allow multiple prefixes with JSON constraint

### DIFF
--- a/backends/exllamav2/grammar.py
+++ b/backends/exllamav2/grammar.py
@@ -79,8 +79,11 @@ class ExLlamaV2Grammar:
 
             return
 
+        # Allow JSON objects or JSON arrays at the top level
+        json_prefixes = ["[", "{"]
+
         lmfilter = ExLlamaV2TokenEnforcerFilter(schema_parser, tokenizer)
-        prefix_filter = ExLlamaV2PrefixFilter(model, tokenizer, "{")
+        prefix_filter = ExLlamaV2PrefixFilter(model, tokenizer, json_prefixes)
 
         # Append the filters
         self.filters.extend([lmfilter, prefix_filter])


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
Fix for #127

**Why should this feature be added?**
Allows first character of JSON completion to be either "[" or "{", preventing "Filter excluded all tokens" error when the JSON schema defines a top-level array.

**Examples**
N/A

**Additional context**
Requires exllamav2>=0.1.4