### PR TITLE
Warn if cache size is too small for CFG

### DIFF
--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -219,6 +219,14 @@ class ExllamaV2Container:
 
             cache_size = rounded_cache_size
 
+        # Warn user if cache size may be inadequate for CFG
+        if cache_size < 2 * self.config.max_seq_len:
+            logger.warning(
+                f"The given cache_size ({cache_size}) is less than 2 * max_seq_len "
+                "and may be too small for requests using CFG. \n"
+                "Ignore this warning if you do not plan on using CFG."
+            )
+
         self.cache_size = cache_size
 
         # Enable fasttensors loading if present


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
Users who do not specify a `cache_size` manually will end up with a default cache that is too small for CFG.

**Why should this feature be added?**
This warns the user that they should set the `cache_size` to at least `2 * max_seq_len` to avoid running out of pages when prompting with CFG.

**Examples**
N/A

**Additional context**
This will warn the user that https://github.com/theroyallab/tabbyAPI/issues/119 may occur.
