### PR TITLE
Fix disabling flash attention in exl2 config

### DIFF
--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -213,6 +213,7 @@ class ExllamaV2Container:
             self.config.no_flash_attn = True
             self.paged = False
             self.max_batch_size = 1
+            torch.backends.cuda.enable_flash_sdp(False)
         elif not supports_paged_attn():
             logger.warning(
                 "Flash attention version >=2.5.7 "
@@ -233,6 +234,7 @@ class ExllamaV2Container:
             self.config.no_flash_attn = True
             self.paged = False
             self.max_batch_size = 1
+            torch.backends.cuda.enable_flash_sdp(False)
 
         # Set k/v cache size
         # cache_size is only relevant when paged mode is enabled

--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -333,6 +333,7 @@ class ExllamaV2Container:
 
         if enable_draft:
             self.draft_config = ExLlamaV2Config()
+            self.draft_config.no_flash_attn = self.config.no_flash_attn
             draft_model_path = pathlib.Path(
                 unwrap(draft_args.get("draft_model_dir"), "models")
             )

--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -210,6 +210,7 @@ class ExllamaV2Container:
                 "To disable compatability mode, all GPUs must be ampere "
                 "(30 series) or newer. AMD GPUs are not supported."
             )
+            self.config.no_flash_attn = True
             self.paged = False
             self.max_batch_size = 1
         elif not supports_paged_attn():
@@ -229,6 +230,7 @@ class ExllamaV2Container:
                 "pip install --upgrade .[cu118]\n\n"
                 "NOTE: Windows users must use CUDA 12.x to use flash-attn."
             )
+            self.config.no_flash_attn = True
             self.paged = False
             self.max_batch_size = 1
 


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
Paged mode was being correctly disabled for unsupported setups, however exllamav2 requires that flash attention also be manually disabled for unsupported configurations even when falling back to compatibility mode.

**Why should this feature be added?**
Resolves https://github.com/theroyallab/tabbyAPI/issues/135

**Examples**
N/A

**Additional context**
This has the side effect of disabling flash attention for users with `2.2.1 <= flash-attn version < 2.5.7` to avoid additional checks. This was felt to be acceptable as all setups that support `flash-attn >= 2.2.1` will also support `flash-attn >= 2.5.7` and users will be prompted to upgrade.
