### PR TITLE
Fix exception unloading models.

### DIFF
--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -739,8 +739,9 @@ class ExllamaV2Container:
                 self.tokenizer = None
 
                 # Cleanup the generator from any pending jobs
-                await self.generator.close()
-                self.generator = None
+                if self.generator is not None:
+                    await self.generator.close()
+                    self.generator = None
 
                 # Set all model state variables to False
                 self.model_is_loading = False


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**

If v1/model/load is cancelled:

ERROR:    Model load cancelled by user. Please make sure to run unload to free up resources.

then the next call to v1/model/load throws during cleanup, since self.generator is None:

```
Traceback (most recent call last):
  File "tabbyAPI/endpoints/OAI/utils/model.py", line 50, in stream_model_load
    async for module, modules, model_type in load_status:
  File "tabbyAPI/common/model.py", line 47, in load_model_gen
    await unload_model()
  File "tabbyAPI/common/model.py", line 27, in unload_model
    await container.unload(skip_wait=skip_wait)
  File "tabbyAPI/backends/exllamav2/model.py", line 742, in unload
    await self.generator.close()

ERROR:    AttributeError: 'NoneType' object has no attribute 'close'
```
