### PR TITLE
Tokenizer data fix

### DIFF
--- a/backends/exllamav2/grammar.py
+++ b/backends/exllamav2/grammar.py
@@ -61,7 +61,8 @@ def _get_lmfe_tokenizer_data(tokenizer: ExLlamaV2Tokenizer):
 
 
 def clear_grammar_func_cache():
-    """Flush tokenizer_data cache to avoid holding references to tokenizers after unloading a model"""
+    """Flush tokenizer_data cache to avoid holding references to
+    tokenizers after unloading a model"""
 
     _get_lmfe_tokenizer_data.clear_cache()
 

--- a/backends/exllamav2/grammar.py
+++ b/backends/exllamav2/grammar.py
@@ -2,7 +2,10 @@ import traceback
 from exllamav2 import ExLlamaV2, ExLlamaV2Tokenizer
 from exllamav2.generator.filters import ExLlamaV2Filter, ExLlamaV2PrefixFilter
 from lmformatenforcer import JsonSchemaParser, RegexParser
-from lmformatenforcer.integrations.exllamav2 import ExLlamaV2TokenEnforcerFilter, build_token_enforcer_tokenizer_data
+from lmformatenforcer.integrations.exllamav2 import (
+    ExLlamaV2TokenEnforcerFilter,
+    build_token_enforcer_tokenizer_data,
+)
 from loguru import logger
 from typing import List
 from functools import lru_cache
@@ -56,6 +59,7 @@ class ExLlamaV2EbnfFilter(ExLlamaV2Filter):
 def _get_lmfe_tokenizer_data(tokenizer: ExLlamaV2Tokenizer):
     return build_token_enforcer_tokenizer_data(tokenizer)
 
+
 def clear_grammar_func_cache():
     """Flush tokenizer_data cache to avoid holding references to tokenizers after unloading a model"""
 
@@ -93,7 +97,9 @@ class ExLlamaV2Grammar:
         # Allow JSON objects or JSON arrays at the top level
         json_prefixes = ["[", "{"]
 
-        lmfilter = ExLlamaV2TokenEnforcerFilter(schema_parser, _get_lmfe_tokenizer_data(tokenizer))
+        lmfilter = ExLlamaV2TokenEnforcerFilter(
+            schema_parser, _get_lmfe_tokenizer_data(tokenizer)
+        )
         prefix_filter = ExLlamaV2PrefixFilter(model, tokenizer, json_prefixes)
 
         # Append the filters
@@ -118,7 +124,9 @@ class ExLlamaV2Grammar:
 
             return
 
-        lmfilter = ExLlamaV2TokenEnforcerFilter(pattern_parser, _get_lmfe_tokenizer_data(tokenizer))
+        lmfilter = ExLlamaV2TokenEnforcerFilter(
+            pattern_parser, _get_lmfe_tokenizer_data(tokenizer)
+        )
 
         # Append the filters
         self.filters.append(lmfilter)

--- a/backends/exllamav2/grammar.py
+++ b/backends/exllamav2/grammar.py
@@ -56,6 +56,11 @@ class ExLlamaV2EbnfFilter(ExLlamaV2Filter):
 def _get_lmfe_tokenizer_data(tokenizer: ExLlamaV2Tokenizer):
     return build_token_enforcer_tokenizer_data(tokenizer)
 
+def clear_grammar_func_cache():
+    """Flush tokenizer_data cache to avoid holding references to tokenizers after unloading a model"""
+
+    _get_lmfe_tokenizer_data.clear_cache()
+
 
 class ExLlamaV2Grammar:
     """ExLlamaV2 class for various grammar filters/parsers."""

--- a/backends/exllamav2/grammar.py
+++ b/backends/exllamav2/grammar.py
@@ -52,6 +52,11 @@ class ExLlamaV2EbnfFilter(ExLlamaV2Filter):
         return self.fsm.allowed_token_ids(self.state), set()
 
 
+@lru_cache(10)
+def _get_lmfe_tokenizer_data(tokenizer: ExLlamaV2Tokenizer):
+    return build_token_enforcer_tokenizer_data(tokenizer)
+
+
 class ExLlamaV2Grammar:
     """ExLlamaV2 class for various grammar filters/parsers."""
 
@@ -59,10 +64,6 @@ class ExLlamaV2Grammar:
 
     def __init__(self):
         self.filters = []
-
-    @lru_cache(10)
-    def _get_lmfe_tokenizer_data(self, tokenizer: ExLlamaV2Tokenizer):
-        return build_token_enforcer_tokenizer_data(tokenizer)
 
     def add_json_schema_filter(
         self,
@@ -87,7 +88,7 @@ class ExLlamaV2Grammar:
         # Allow JSON objects or JSON arrays at the top level
         json_prefixes = ["[", "{"]
 
-        lmfilter = ExLlamaV2TokenEnforcerFilter(schema_parser, self._get_lmfe_tokenizer_data(tokenizer))
+        lmfilter = ExLlamaV2TokenEnforcerFilter(schema_parser, _get_lmfe_tokenizer_data(tokenizer))
         prefix_filter = ExLlamaV2PrefixFilter(model, tokenizer, json_prefixes)
 
         # Append the filters
@@ -112,7 +113,7 @@ class ExLlamaV2Grammar:
 
             return
 
-        lmfilter = ExLlamaV2TokenEnforcerFilter(pattern_parser, self._get_lmfe_tokenizer_data(tokenizer))
+        lmfilter = ExLlamaV2TokenEnforcerFilter(pattern_parser, _get_lmfe_tokenizer_data(tokenizer))
 
         # Append the filters
         self.filters.append(lmfilter)

--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -26,7 +26,10 @@ from itertools import zip_longest
 from loguru import logger
 from typing import List, Optional, Union
 
-from backends.exllamav2.grammar import ExLlamaV2Grammar
+from backends.exllamav2.grammar import (
+    ExLlamaV2Grammar,
+    clear_grammar_func_cache,
+)
 from backends.exllamav2.utils import (
     exllama_disabled_flash_attn,
     hardware_supports_flash_attn,
@@ -704,6 +707,10 @@ class ExllamaV2Container:
             # Wait for other jobs to finish
             await self.wait_for_jobs(kwargs.get("skip_wait"))
 
+            # Delete references held in the grammar module
+            clear_grammar_func_cache()
+
+            # Unload LoRAs
             if self.generator and self.generator.generator.current_loras:
                 for lora in self.generator.generator.current_loras:
                     lora.unload()


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
Slow initialization of constrained requests due to each request recreating the same instance of LMFE's tokenizer data class, which is a slightly expensive operation.

**Why should this feature be added?**
Fixes the above by caching the tokenizer data.

**Examples**
N/A

**Additional context**
N/A
