### PR TITLE
Fix: AttributeError: 'NoneType' object has no attribute 'verify_key' when disable_auth: True

### DIFF
--- a/common/auth.py
+++ b/common/auth.py
@@ -84,6 +84,9 @@ def get_key_permission(request: Request):
     Internal only! Use the depends functions for incoming requests.
     """
 
+    if DISABLE_AUTH:
+        return "admin"
+
     # Hyphens are okay here
     test_key = coalesce(
         request.headers.get("x-admin-key"),


### PR DESCRIPTION
Fix: AttributeError: 'NoneType' object has no attribute 'verify_key'
when disable_auth: True

AUTH_KEYS is used while still None when disable_auth is True.

```
   raw_response = await run_endpoint_function(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/fastapi/routing.py", 
tabbyapi-1  | line 191, in run_endpoint_function
    return await dependant.call(**values)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/tabbyAPI/endpoints/core/router.py", line 62, in 
tabbyapi-1  | list_models
    if get_key_permission(request) == "admin":
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/tabbyAPI/common/auth.py", line 100, in 
tabbyapi-1  | get_key_permission
    if AUTH_KEYS.verify_key(test_key, "admin_key"):
       ^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'verify_key'
```