### PR TITLE
Improve docker deployment configuration

### DIFF
--- a/api_tokens_sample.yml
+++ b/api_tokens_sample.yml
@@ -1,0 +1,2 @@
+api_key: # Insert api key here
+admin_key: # Insert admin key here

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -2,3 +2,5 @@ models/
 loras/
 .ruff_cache/
 **/__pycache__/
+config.yml
+api_tokens.yml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,5 @@
 # Use an official CUDA runtime with Ubuntu as a parent image
-FROM nvidia/cuda:12.4.1-runtime-ubuntu22.04
-
-ARG GIT_REPO=https://github.com/theroyallab/tabbyAPI
-ARG DO_PULL=true
-ENV DO_PULL $DO_PULL
-
-# Set the working directory in the container
-WORKDIR /app
+FROM nvidia/cuda:12.1.0-runtime-ubuntu22.04
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -15,19 +8,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     python3.11 \
     python3-pip \
-    git \
     && rm -rf /var/lib/apt/lists/*
-
-# Update repo
-RUN if [ ${DO_PULL} ]; then \
-    git init && \
-    git remote add origin $GIT_REPO && \
-    git fetch origin && \
-    git pull origin main && \
-    echo "Pull finished"; fi
 
 # Upgrade pip
 RUN pip3 install --no-cache-dir --upgrade pip
+
+# Set the working directory in the container
+WORKDIR /app
 
 # Get requirements
 COPY pyproject.toml .
@@ -37,9 +24,6 @@ RUN pip3 install --no-cache-dir .[cu121]
 
 # Copy the current directory contents into the container
 COPY . .
-
-# Create a config.yml
-COPY config_sample.yml config.yml
 
 # Make port 5000 available to the world outside this container
 EXPOSE 5000

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,7 +12,9 @@ services:
       - NAME=TabbyAPI
       - NVIDIA_VISIBLE_DEVICES=all
     volumes:
-      - ./models:/app/models
+      # - /path/to/models:/app/models                       # Change me
+      # - /path/to/config.yml:/app/config.yml               # Change me
+      # - /path/to/api_tokens.yml:/app/api_tokens.yml       # Change me
     deploy:
       resources:
         reservations:


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
This PR improves the docker workflow for deploying tabbyAPI. It moves the deployment configuration outside the docker image. This allows us to change the deployment configurations such as model, host and port without having to rebuild the docker image.

Additionally, I create a sample for `api_tokens.yml` named  `api_tokens_sample.yml`. This makes it easier for new users to understand how to persist their auth tokens.

**Why should this feature be added?**
It makes working with docker a lot easier

**Wiki**
The [wiki](https://github.com/theroyallab/tabbyAPI/wiki/1.-Getting-Started#docker) should be updated to account for the changes. Suggested version:
Docker
1. Install Docker and docker compose from the [docs](https://docs.docker.com/compose/install/)
2. Install the Nvidia container compatibility layer
i. For Linux: [Nvidia container toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html)
ii. For Windows: [Cuda Toolkit on WSL](https://docs.nvidia.com/cuda/wsl-user-guide/index.html)
3. Clone TabbyAPI via git clone https://github.com/theroyallab/tabbyAPI
4. Enter the tabbyAPI directory by cd tabbyAPI
5. Create a `config.yml` file from the `config_sample.yml` to set up the configurations such as model, host and port
6. [optional] Create a `api_tokens.yml` to specify your api key and admin key. If this step is skipped, they will be auto generated.
7. Update the volume mount section in the `docker/docker-compose.yml` file:
```
    volumes:
      # - /path/to/models:/app/models                       # Change me
      # - /path/to/config.yml:/app/config.yml               # Change me
      # - /path/to/api_tokens.yml:/app/api_tokens.yml       # Change me
```
9. Run docker compose -f docker/docker-compose.yml up

**Additional context**
Follow up from
https://github.com/theroyallab/tabbyAPI/pull/150
