### PR TITLE
Model: Fix draft model loading

### DIFF
--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -682,7 +682,7 @@ class ExllamaV2Container:
             )
         else:
             return cache_class(
-                self.model,
+                self.model or self.draft_model,
                 max_seq_len=self.cache_size,
                 lazy=autosplit,
                 batch_size=1,


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
The problem is that when a draft model is added and the cache class is attempting to load the `self.model` object which is `None` and `.config` cannot be found because the model that is loaded at the time of draft cache creation is `self.draft_model`

**Why should this feature be added?**
Who doesn't enjoy extra tokens per second.

