### PR TITLE
Add healthcheck

### DIFF
--- a/common/auth.py
+++ b/common/auth.py
@@ -162,3 +162,13 @@ async def check_admin_key(
         return authorization
 
     raise HTTPException(401, "Please provide an admin key")
+
+async def check_localhost(request: Request):
+    """
+    Dependency that raises an HTTP 403 Forbidden error if the request does not come from localhost.
+    """
+    client_host = request.client.host
+    if client_host not in ["127.0.0.1", "localhost", "::1"]:
+        raise HTTPException(
+            status_code=401, detail="Access forbidden: Localhost only"
+        )

--- a/common/auth.py
+++ b/common/auth.py
@@ -162,13 +162,3 @@ async def check_admin_key(
         return authorization
 
     raise HTTPException(401, "Please provide an admin key")
-
-async def check_localhost(request: Request):
-    """
-    Dependency that raises an HTTP 403 Forbidden error if the request does not come from localhost.
-    """
-    client_host = request.client.host
-    if client_host not in ["127.0.0.1", "localhost", "::1"]:
-        raise HTTPException(
-            status_code=401, detail="Access forbidden: Localhost only"
-        )

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - "5000:5000"
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:5000/healthcheck"]
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:5000/health"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,6 +8,11 @@ services:
         - DO_PULL=true
     ports:
       - "5000:5000"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://127.0.0.1:5000/healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     environment:
       - NAME=TabbyAPI
       - NVIDIA_VISIBLE_DEVICES=all

--- a/endpoints/core/router.py
+++ b/endpoints/core/router.py
@@ -43,13 +43,13 @@ from endpoints.core.utils.model import (
 
 router = APIRouter()
 
+
 # Healthcheck endpoint
-@router.get(
-    "/health",
-)
-async def healthcheck() :
+@router.get("/health")
+async def healthcheck():
     """Get the current service health status"""
     return {"status": "healthy"}
+
 
 # Model list endpoint
 @router.get("/v1/models", dependencies=[Depends(check_api_key)])
@@ -526,4 +526,3 @@ async def unload_sampler_override():
     """Unloads the currently selected override preset"""
 
     sampling.overrides_from_dict({})
-

--- a/endpoints/core/router.py
+++ b/endpoints/core/router.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from sse_starlette import EventSourceResponse
 
 from common import config, model, sampling
-from common.auth import check_admin_key, check_api_key, get_key_permission
+from common.auth import check_admin_key, check_api_key, get_key_permission, check_localhost
 from common.downloader import hf_repo_download
 from common.model import check_embeddings_container, check_model_container
 from common.networking import handle_request_error, run_with_request_disconnect
@@ -519,3 +519,12 @@ async def unload_sampler_override():
     """Unloads the currently selected override preset"""
 
     sampling.overrides_from_dict({})
+
+
+@router.get(
+    "/healthcheck",
+    dependencies=[Depends(check_localhost)],
+    # include_in_schema=False
+)
+async def healthcheck() :
+    return {"status": "healthy"}

--- a/endpoints/core/router.py
+++ b/endpoints/core/router.py
@@ -43,6 +43,13 @@ from endpoints.core.utils.model import (
 
 router = APIRouter()
 
+# Healthcheck endpoint
+@router.get(
+    "/health",
+)
+async def healthcheck() :
+    """Get the current service health status"""
+    return {"status": "healthy"}
 
 # Model list endpoint
 @router.get("/v1/models", dependencies=[Depends(check_api_key)])
@@ -520,11 +527,3 @@ async def unload_sampler_override():
 
     sampling.overrides_from_dict({})
 
-
-@router.get(
-    "/health",
-    dependencies=[],
-)
-async def healthcheck() :
-    """Get the current service health status"""
-    return {"status": "healthy"}

--- a/endpoints/core/router.py
+++ b/endpoints/core/router.py
@@ -5,7 +5,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from sse_starlette import EventSourceResponse
 
 from common import config, model, sampling
-from common.auth import check_admin_key, check_api_key, get_key_permission, check_localhost
+from common.auth import check_admin_key, check_api_key, get_key_permission
 from common.downloader import hf_repo_download
 from common.model import check_embeddings_container, check_model_container
 from common.networking import handle_request_error, run_with_request_disconnect
@@ -522,9 +522,9 @@ async def unload_sampler_override():
 
 
 @router.get(
-    "/healthcheck",
-    dependencies=[Depends(check_localhost)],
-    # include_in_schema=False
+    "/health",
+    dependencies=[],
 )
 async def healthcheck() :
+    """Get the current service health status"""
     return {"status": "healthy"}


### PR DESCRIPTION
Adds:
- localhost only /healthcheck endpoint
- cURL healthcheck in docker compose file

**Why should this feature be added?**
A healthcheck allows the docker daemon to restart tabbyAPI in case of a crash

**Examples**
If the tabbyAPI server crashes and hangs indefinitely then docker will not restart the application without a health check
