### PR TITLE
make docker-compose use prebuilt images

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,11 +1,7 @@
 version: '3.8'
 services:
   tabbyapi:
-    build:
-      context: ..
-      dockerfile: ./docker/Dockerfile
-      args:
-        - DO_PULL=true
+    image: ghcr.io/theroyallab/tabbyapi:latest
     ports:
       - "5000:5000"
     healthcheck:


### PR DESCRIPTION
- Docker compose uses the prebuilt images produced by the GitHub action added in 872eeed581380ae032dfc039479934ce9a55e6f3

**Why should this feature be added?**
There are prebuilt docker images that are known to work provided by the existing github action. It seems reasonable to use them by default instead of having every end user duplicate the effort and compile their own image.

Benefits include:
- lower start-up time
- lower initial complexity for end users
- no requirement to clone the git repo