### PR TITLE
Override default model load parameters via yaml

### DIFF
--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -63,6 +63,10 @@ except ImportError:
 class ExllamaV2Container:
     """The model container class for ExLlamaV2 models."""
 
+    # Model directories
+    model_dir: pathlib.Path = pathlib.Path("models")
+    draft_model_dir: pathlib.Path = pathlib.Path("models")
+
     # Exl2 vars
     config: Optional[ExLlamaV2Config] = None
     draft_config: Optional[ExLlamaV2Config] = None
@@ -110,6 +114,7 @@ class ExllamaV2Container:
 
         # Initialize config
         self.config = ExLlamaV2Config()
+        self.model_dir = model_directory
         self.config.model_dir = str(model_directory.resolve())
 
         # Make the max seq len 4096 before preparing the config
@@ -142,6 +147,7 @@ class ExllamaV2Container:
             )
             draft_model_path = draft_model_path / draft_model_name
 
+            self.draft_model_dir = draft_model_path
             self.draft_config.model_dir = str(draft_model_path.resolve())
             self.draft_config.prepare()
 
@@ -403,20 +409,9 @@ class ExllamaV2Container:
             alpha = -0.13436 + 0.80541 * ratio + 0.28833 * ratio**2
         return alpha
 
-    def get_model_path(self, is_draft: bool = False):
-        """Get the path for this model."""
-
-        if is_draft and not self.draft_config:
-            return None
-
-        model_path = pathlib.Path(
-            self.draft_config.model_dir if is_draft else self.config.model_dir
-        )
-        return model_path
-
     def get_model_parameters(self):
         model_params = {
-            "name": self.get_model_path().name,
+            "name": self.model_dir.name,
             "rope_scale": self.config.scale_pos_emb,
             "rope_alpha": self.config.scale_alpha_value,
             "max_seq_len": self.config.max_seq_len,
@@ -431,7 +426,7 @@ class ExllamaV2Container:
 
         if self.draft_config:
             draft_model_params = {
-                "name": self.get_model_path(is_draft=True).name,
+                "name": self.draft_model_dir.name,
                 "rope_scale": self.draft_config.scale_pos_emb,
                 "rope_alpha": self.draft_config.scale_alpha_value,
                 "max_seq_len": self.draft_config.max_seq_len,

--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -347,6 +347,9 @@ class ExllamaV2Container:
 
         # Set user-configured draft model values
         if enable_draft:
+            # Fetch from the updated kwargs
+            draft_args = unwrap(kwargs.get("draft"), {})
+
             self.draft_config.max_seq_len = self.config.max_seq_len
 
             self.draft_config.scale_pos_emb = unwrap(
@@ -378,9 +381,15 @@ class ExllamaV2Container:
             return kwargs
 
         with open(override_config_path, "r", encoding="utf8") as override_config_file:
-            override_config = unwrap(yaml.safe_load(override_config_file), {})
-            merged_kwargs = {**override_config, **kwargs}
+            override_args = unwrap(yaml.safe_load(override_config_file), {})
 
+            # Merge draft overrides beforehand
+            draft_override_args = unwrap(override_args.get("draft"), {})
+            if self.draft_config and draft_override_args:
+                kwargs["draft"] = {**draft_override_args, **kwargs.get("draft")}
+
+            # Merge the override and model kwargs
+            merged_kwargs = {**override_args, **kwargs}
             return merged_kwargs
 
     def find_prompt_template(self, prompt_template_name, model_directory):

--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -361,6 +361,8 @@ class ExllamaV2Container:
                 self.draft_config.max_attention_size = chunk_size**2
 
     def set_model_overrides(self, **kwargs):
+        """Sets overrides from a model folder's config yaml."""
+
         override_config_path = self.model_dir / "tabby_config.yml"
 
         if not override_config_path.exists():

--- a/common/args.py
+++ b/common/args.py
@@ -13,6 +13,24 @@ def str_to_bool(value):
     raise ValueError(f"{value} is not a valid boolean value")
 
 
+def argument_with_auto(value):
+    """
+    Argparse type wrapper for any argument that has an automatic option.
+
+    Ex. rope_alpha
+    """
+
+    if value == "auto":
+        return "auto"
+
+    try:
+        return float(value)
+    except ValueError as ex:
+        raise argparse.ArgumentTypeError(
+            'This argument only takes a type of float or "auto"'
+        ) from ex
+
+
 def init_argparser():
     """Creates an argument parser that any function can use"""
 
@@ -133,7 +151,11 @@ def add_model_args(parser: argparse.ArgumentParser):
     model_group.add_argument(
         "--rope-scale", type=float, help="Sets rope_scale or compress_pos_emb"
     )
-    model_group.add_argument("--rope-alpha", type=float, help="Sets rope_alpha for NTK")
+    model_group.add_argument(
+        "--rope-alpha",
+        type=argument_with_auto,
+        help="Sets rope_alpha for NTK",
+    )
     model_group.add_argument(
         "--cache-mode",
         type=str,

--- a/common/model.py
+++ b/common/model.py
@@ -149,7 +149,7 @@ async def unload_embedding_model():
     embeddings_container = None
 
 
-def get_config_default(key: str, fallback=None, model_type: str = "model"):
+def get_config_default(key: str, model_type: str = "model"):
     """Fetches a default value from model config if allowed by the user."""
 
     model_config = config.model_config()
@@ -162,14 +162,12 @@ def get_config_default(key: str, fallback=None, model_type: str = "model"):
         # Is this a draft model load parameter?
         if model_type == "draft":
             draft_config = config.draft_model_config()
-            return unwrap(draft_config.get(key), fallback)
+            return draft_config.get(key)
         elif model_type == "embedding":
             embeddings_config = config.embeddings_config()
-            return unwrap(embeddings_config.get(key), fallback)
+            return embeddings_config.get(key)
         else:
-            return unwrap(model_config.get(key), fallback)
-    else:
-        return fallback
+            return model_config.get(key)
 
 
 async def check_model_container():

--- a/common/model.py
+++ b/common/model.py
@@ -149,6 +149,7 @@ async def unload_embedding_model():
     embeddings_container = None
 
 
+# FIXME: Maybe make this a one-time function instead of a dynamic default
 def get_config_default(key: str, model_type: str = "model"):
     """Fetches a default value from model config if allowed by the user."""
 

--- a/common/model.py
+++ b/common/model.py
@@ -57,7 +57,7 @@ async def load_model_gen(model_path: pathlib.Path, **kwargs):
 
     # Check if the model is already loaded
     if container and container.model:
-        loaded_model_name = container.get_model_path().name
+        loaded_model_name = container.model_dir.name
 
         if loaded_model_name == model_path.name and container.model_loaded:
             raise ValueError(

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -135,7 +135,8 @@ model:
 
   # Rope alpha (default: 1.0)
   # Same thing as alpha_value
-  # Leave blank to automatically calculate alpha
+  # Set to "auto" to automatically calculate
+  # Leave blank to pull the value from the model
   #rope_alpha: 1.0
 
   # Enable different cache modes for VRAM savings (slight performance hit).

--- a/endpoints/OAI/router.py
+++ b/endpoints/OAI/router.py
@@ -52,7 +52,7 @@ async def completion_request(
     If stream = true, this returns an SSE stream.
     """
 
-    model_path = model.container.get_model_path()
+    model_path = model.container.model_dir
 
     if isinstance(data.prompt, list):
         data.prompt = "\n".join(data.prompt)
@@ -105,7 +105,7 @@ async def chat_completion_request(
 
         raise HTTPException(422, error_message)
 
-    model_path = model.container.get_model_path()
+    model_path = model.container.model_dir
 
     if isinstance(data.messages, str):
         prompt = data.messages

--- a/endpoints/core/types/model.py
+++ b/endpoints/core/types/model.py
@@ -53,19 +53,19 @@ class DraftModelLoadRequest(BaseModel):
     # Config arguments
     draft_rope_scale: Optional[float] = Field(
         default_factory=lambda: get_config_default(
-            "draft_rope_scale", 1.0, model_type="draft"
+            "draft_rope_scale", model_type="draft"
         )
     )
     draft_rope_alpha: Optional[float] = Field(
         description="Automatically calculated if not present",
         default_factory=lambda: get_config_default(
-            "draft_rope_alpha", None, model_type="draft"
+            "draft_rope_alpha", model_type="draft"
         ),
         examples=[1.0],
     )
     draft_cache_mode: Optional[str] = Field(
         default_factory=lambda: get_config_default(
-            "draft_cache_mode", "FP16", model_type="draft"
+            "draft_cache_mode", model_type="draft"
         )
     )
 
@@ -97,16 +97,16 @@ class ModelLoadRequest(BaseModel):
         examples=[4096],
     )
     tensor_parallel: Optional[bool] = Field(
-        default_factory=lambda: get_config_default("tensor_parallel", False)
+        default_factory=lambda: get_config_default("tensor_parallel")
     )
     gpu_split_auto: Optional[bool] = Field(
-        default_factory=lambda: get_config_default("gpu_split_auto", True)
+        default_factory=lambda: get_config_default("gpu_split_auto")
     )
     autosplit_reserve: Optional[List[float]] = Field(
-        default_factory=lambda: get_config_default("autosplit_reserve", [96])
+        default_factory=lambda: get_config_default("autosplit_reserve")
     )
     gpu_split: Optional[List[float]] = Field(
-        default_factory=lambda: get_config_default("gpu_split", []),
+        default_factory=lambda: get_config_default("gpu_split"),
         examples=[[24.0, 20.0]],
     )
     rope_scale: Optional[float] = Field(
@@ -120,10 +120,10 @@ class ModelLoadRequest(BaseModel):
         examples=[1.0],
     )
     cache_mode: Optional[str] = Field(
-        default_factory=lambda: get_config_default("cache_mode", "FP16")
+        default_factory=lambda: get_config_default("cache_mode")
     )
     chunk_size: Optional[int] = Field(
-        default_factory=lambda: get_config_default("chunk_size", 2048)
+        default_factory=lambda: get_config_default("chunk_size")
     )
     prompt_template: Optional[str] = Field(
         default_factory=lambda: get_config_default("prompt_template")
@@ -132,7 +132,7 @@ class ModelLoadRequest(BaseModel):
         default_factory=lambda: get_config_default("num_experts_per_token")
     )
     fasttensors: Optional[bool] = Field(
-        default_factory=lambda: get_config_default("fasttensors", False)
+        default_factory=lambda: get_config_default("fasttensors")
     )
 
     # Non-config arguments

--- a/endpoints/core/types/model.py
+++ b/endpoints/core/types/model.py
@@ -2,7 +2,7 @@
 
 from pydantic import BaseModel, Field, ConfigDict
 from time import time
-from typing import List, Optional
+from typing import List, Literal, Optional, Union
 
 from common.gen_logging import GenLogPreferences
 from common.model import get_config_default
@@ -56,8 +56,8 @@ class DraftModelLoadRequest(BaseModel):
             "draft_rope_scale", model_type="draft"
         )
     )
-    draft_rope_alpha: Optional[float] = Field(
-        description="Automatically calculated if not present",
+    draft_rope_alpha: Optional[Union[float, Literal["auto"]]] = Field(
+        description='Automatically calculated if set to "auto"',
         default_factory=lambda: get_config_default(
             "draft_rope_alpha", model_type="draft"
         ),
@@ -114,8 +114,8 @@ class ModelLoadRequest(BaseModel):
         default_factory=lambda: get_config_default("rope_scale"),
         examples=[1.0],
     )
-    rope_alpha: Optional[float] = Field(
-        description="Automatically calculated if not present",
+    rope_alpha: Optional[Union[float, Literal["auto"]]] = Field(
+        description='Automatically calculated if set to "auto"',
         default_factory=lambda: get_config_default("rope_alpha"),
         examples=[1.0],
     )

--- a/endpoints/core/utils/model.py
+++ b/endpoints/core/utils/model.py
@@ -43,11 +43,12 @@ async def get_current_model_list(model_type: str = "model"):
     model_path = None
 
     # Make sure the model container exists
-    if model_type == "model" or model_type == "draft":
-        if model.container:
-            model_path = model.container.get_model_path(model_type == "draft")
-    elif model_type == "embedding":
-        if model.embeddings_container:
+    match model_type:
+        case "model":
+            model_path = model.container.model_dir
+        case "draft":
+            model_path = model.container.draft_model_dir
+        case "embedding":
             model_path = model.embeddings_container.model_dir
 
     if model_path:

--- a/endpoints/core/utils/model.py
+++ b/endpoints/core/utils/model.py
@@ -95,8 +95,10 @@ async def stream_model_load(
 ):
     """Request generation wrapper for the loading process."""
 
+    # Get trimmed load data
+    load_data = data.model_dump(exclude_none=True)
+
     # Set the draft model path if it exists
-    load_data = data.model_dump()
     if draft_model_path:
         load_data["draft"]["draft_model_dir"] = draft_model_path
 


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
Currently, setting up a model configuration can be difficult for users since many parameters are hard to understand and a model's `config.json` is unreadable and rarely modified.

**Why should this feature be added?**
This feature adds support for users and model developers to add a `tabby_config.yml` file which provides an extra configuration layer for load parameters.

Any key from the `model` block of config.yml is supported in this file. So, draft model overrides are possible as well.

For example, Llama 3.1 has a max_seq_len of 128000 by default unless otherwise specified in either the API request or the user's config.yml file. Now, a user can add a `tabby_config.yml` file in the model folder which has the line `max_seq_len: 8192` and that will make the default fallback to 8192 instead of 128000.

If a model dev adds this file to their huggingface repo, users can download and the fallback parameters should be automatically applied.

**Additional context**
Related to #130 and #118.
