### PR TITLE
Complete conditional infinity import TODO

### DIFF
--- a/backends/infinity/model.py
+++ b/backends/infinity/model.py
@@ -7,13 +7,13 @@ from typing import List, Optional
 from common.utils import unwrap
 
 # Conditionally import infinity to sidestep its logger
-# TODO: Make this prettier
+has_infinity_emb: bool = False
 try:
     from infinity_emb import EngineArgs, AsyncEmbeddingEngine
-
     has_infinity_emb = True
+    logger.debug("Successfully imported infinity.")
 except ImportError:
-    has_infinity_emb = False
+    logger.debug("Failed to import infinity.")
 
 
 class InfinityContainer:

--- a/backends/infinity/model.py
+++ b/backends/infinity/model.py
@@ -10,10 +10,10 @@ from common.utils import unwrap
 has_infinity_emb: bool = False
 try:
     from infinity_emb import EngineArgs, AsyncEmbeddingEngine
+
     has_infinity_emb = True
-    logger.debug("Successfully imported infinity.")
 except ImportError:
-    logger.debug("Failed to import infinity.")
+    pass
 
 
 class InfinityContainer:


### PR DESCRIPTION
**Why should this feature be added?**
- additional logging
- changed declaration order prevents has_infinity_emb becoming undefined when there are errors other then import error
- added additional type hinting

**Examples**
The software is more likely to crash without these changes if there is an issue with the infinity embed backend

**Additional context**
completes a TODO in the code
