### PR TITLE
rewrite API keys implementation

### DIFF
--- a/common/auth.py
+++ b/common/auth.py
@@ -6,159 +6,202 @@ application, it should be fine.
 import secrets
 import yaml
 from fastapi import Header, HTTPException, Request
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from loguru import logger
-from typing import Optional
+from typing import Optional, Union
+from enum import Flag, auto
+from abc import ABC, abstractmethod
 
-from common.utils import coalesce
+from common.utils import coalesce, unwrap
+
+__all__ = ["ROLE", "auth"]
 
 
-class AuthKeys(BaseModel):
-    """
-    This class represents the authentication keys for the application.
-    It contains two types of keys: 'api_key' and 'admin_key'.
-    The 'api_key' is used for general API calls, while the 'admin_key'
-    is used for administrative tasks. The class also provides a method
-    to verify if a given key matches the stored 'api_key' or 'admin_key'.
-    """
+# RBAC roles
+class ROLE(Flag):
+    USER = auto()
+    ADMIN = auto()
 
-    api_key: str
-    admin_key: str
 
-    def verify_key(self, test_key: str, key_type: str):
-        """Verify if a given key matches the stored key."""
-        if key_type == "admin_key":
-            return test_key == self.admin_key
-        if key_type == "api_key":
-            # Admin keys are valid for all API calls
-            return test_key == self.api_key or test_key == self.admin_key
+class API_KEY(BaseModel):
+    """stores an API key"""
+
+    key: str = Field(..., description="the API key value")
+    role: ROLE = Field()
+
+
+class AUTH_PROVIDER(ABC):
+    @staticmethod
+    def add_api_key(role: ROLE) -> API_KEY:
+        """add an API key"""
+
+    @staticmethod
+    def set_api_key(role: ROLE, api_key: str) -> API_KEY:
+        """add an existing API key"""
+
+    @staticmethod
+    def remove_api_key(api_key: str) -> bool:
+        """remove an API key"""
+
+    @staticmethod
+    def check_api_key(api_key: str) -> Union[API_KEY, None]:
+        """check if an API key is valid"""
+
+    @staticmethod
+    def authenticate_api_key(api_key: str, role: ROLE) -> bool:
+        """check if an api key has ROLE"""
+
+
+class SIMPLE_AUTH_PROVIDER(AUTH_PROVIDER):
+    api_keys: list[API_KEY] = []
+
+    def __init__(self) -> None:
+        try:
+            with open("api_tokens.yml", "r", encoding="utf8") as auth_file:
+                keys_dict: dict = yaml.safe_load(auth_file)
+
+                # load legacy keys
+                admin_key = keys_dict.get("admin_key")
+                if admin_key:
+                    self.set_api_key(ROLE.ADMIN, admin_key)
+
+                admin_key = keys_dict.get("api_key")
+                if admin_key:
+                    self.set_api_key(ROLE.USER, admin_key)
+
+                # load new keys
+                admin_keys = keys_dict.get("admin_keys")
+                if admin_keys:
+                    for key in admin_keys:
+                        self.set_api_key(ROLE.ADMIN, key)
+
+                user_keys = keys_dict.get("user_keys")
+                if admin_keys:
+                    for key in admin_keys:
+                        self.set_api_key(ROLE.ADMIN, key)
+
+        except FileNotFoundError:
+            file = {
+                "admin_keys": [
+                    self.add_api_key(ROLE.ADMIN),
+                ],
+                "user_keys": [
+                    self.add_api_key(ROLE.USER),
+                ],
+            }
+
+            with open("api_tokens.yml", "w", encoding="utf8") as auth_file:
+                yaml.safe_dump(file, auth_file, default_flow_style=False)
+
+        logger.info("API keys:")
+        for key in self.api_keys:
+            logger.info(f"{key.role.name} :\t {key.key}")
+        logger.info(
+            "If these keys get compromised, make sure to delete api_tokens.yml and restart the server. Have fun!"
+        )
+
+    def add_api_key(self, role: ROLE) -> API_KEY:
+        return self.set_api_key(key=secrets.token_hex(16), role=role)
+
+    def set_api_key(self, role: ROLE, api_key: str) -> API_KEY:
+        key = API_KEY(key=api_key, role=role)
+        self.api_keys.append(key)
+        return key
+
+    def remove_api_key(self, api_key: str) -> bool:
+        for key in self.api_keys:
+            if key.key == api_key:
+                self.api_keys.remove(key)
+                return True
         return False
 
+    def check_api_key(self, api_key: str) -> Union[API_KEY, None]:
+        for key in self.api_keys:
+            if key.key == api_key:
+                return key
+        return None
 
-# Global auth constants
-AUTH_KEYS: Optional[AuthKeys] = None
-DISABLE_AUTH: bool = False
-
-
-def load_auth_keys(disable_from_config: bool):
-    """Load the authentication keys from api_tokens.yml. If the file does not
-    exist, generate new keys and save them to api_tokens.yml."""
-    global AUTH_KEYS
-    global DISABLE_AUTH
-
-    DISABLE_AUTH = disable_from_config
-    if disable_from_config:
-        logger.warning(
-            "Disabling authentication makes your instance vulnerable. "
-            "Set the `disable_auth` flag to False in config.yml if you "
-            "want to share this instance with others."
-        )
-
-        return
-
-    try:
-        with open("api_tokens.yml", "r", encoding="utf8") as auth_file:
-            auth_keys_dict = yaml.safe_load(auth_file)
-            AUTH_KEYS = AuthKeys.model_validate(auth_keys_dict)
-    except FileNotFoundError:
-        new_auth_keys = AuthKeys(
-            api_key=secrets.token_hex(16), admin_key=secrets.token_hex(16)
-        )
-        AUTH_KEYS = new_auth_keys
-
-        with open("api_tokens.yml", "w", encoding="utf8") as auth_file:
-            yaml.safe_dump(AUTH_KEYS.model_dump(), auth_file, default_flow_style=False)
-
-    logger.info(
-        f"Your API key is: {AUTH_KEYS.api_key}\n"
-        f"Your admin key is: {AUTH_KEYS.admin_key}\n\n"
-        "If these keys get compromised, make sure to delete api_tokens.yml "
-        "and restart the server. Have fun!"
-    )
+    def authenticate_api_key(self, api_key: str, role: ROLE) -> bool:
+        key = self.check_api_key(api_key)
+        print(f"#### {key=}")
+        if not key:
+            return False
+        return key.role & role  # if key.role in role
 
 
-def get_key_permission(request: Request):
-    """
-    Gets the key permission from a request.
+class NOAUTH_AUTH_PROVIDER(AUTH_PROVIDER):
+    def add_api_key(self, role: ROLE) -> API_KEY:
+        return API_KEY(key=secrets.token_hex(16), role=role)
 
-    Internal only! Use the depends functions for incoming requests.
-    """
+    def set_api_key(self, role: ROLE, api_key: str) -> API_KEY:
+        return API_KEY(key=secrets.token_hex(16), role=role)
 
-    # Give full admin permissions if auth is disabled
-    if DISABLE_AUTH:
-        return "admin"
+    def remove_api_key(self, api_key: str) -> bool:
+        return True
 
-    # Hyphens are okay here
-    test_key = coalesce(
-        request.headers.get("x-admin-key"),
-        request.headers.get("x-api-key"),
-        request.headers.get("authorization"),
-    )
+    def check_api_key(self, api_key: str) -> Union[API_KEY, None]:
+        return API_KEY(key=secrets.token_hex(16), role=ROLE.ADMIN)
 
-    if test_key is None:
-        raise ValueError("The provided authentication key is missing.")
-
-    if test_key.lower().startswith("bearer"):
-        test_key = test_key.split(" ")[1]
-
-    if AUTH_KEYS.verify_key(test_key, "admin_key"):
-        return "admin"
-    elif AUTH_KEYS.verify_key(test_key, "api_key"):
-        return "api"
-    else:
-        raise ValueError("The provided authentication key is invalid.")
+    def authenticate_api_key(self, api_key: str, role: ROLE) -> bool:
+        return True
 
 
-async def check_api_key(
-    x_api_key: str = Header(None), authorization: str = Header(None)
-):
-    """Check if the API key is valid."""
+class AUTH_PROVIDER_CONTAINER:
+    provider: AUTH_PROVIDER
 
-    # Allow request if auth is disabled
-    if DISABLE_AUTH:
-        return
+    def load(self, disable_from_config: bool):
+        """Load the authentication keys from api_tokens.yml. If the file does not
+        exist, generate new keys and save them to api_tokens.yml."""
 
-    if x_api_key:
-        if not AUTH_KEYS.verify_key(x_api_key, "api_key"):
-            raise HTTPException(401, "Invalid API key")
-        return x_api_key
+        # TODO: Make provider a paramater instead of disable_from_config
+        provider = "noauth" if disable_from_config else "simple"
 
-    if authorization:
-        split_key = authorization.split(" ")
-        if len(split_key) < 2:
-            raise HTTPException(401, "Invalid API key")
-        if split_key[0].lower() != "bearer" or not AUTH_KEYS.verify_key(
-            split_key[1], "api_key"
+        # allows for more types of providers
+        provider_class = {
+            "noauth": NOAUTH_AUTH_PROVIDER,
+            "simple": SIMPLE_AUTH_PROVIDER,
+        }.get(provider)
+
+        if not provider_class:
+            raise Exception()
+
+        if provider_class == NOAUTH_AUTH_PROVIDER:
+            logger.warning(
+                "Disabling authentication makes your instance vulnerable. "
+                "Set the `disable_auth` flag to False in config.yml if you "
+                "want to share this instance with others."
+            )
+
+        self.provider = provider_class()
+
+    # by returning a dynamic dependency we can have one function where we can specify what roles can access the endpoint
+    def check_api_key(self, role: ROLE):
+        """Check if the API key is valid."""
+
+        async def check(
+            x_api_key: str = Header(None), authorization: str = Header(None)
         ):
-            raise HTTPException(401, "Invalid API key")
+            if x_api_key:
+                if not self.provider.authenticate_api_key(x_api_key, role):
+                    raise HTTPException(401, "Invalid API key")
+                return x_api_key
 
-        return authorization
+            if authorization:
+                split_key = authorization.split(" ")
+                if len(split_key) < 2:
+                    raise HTTPException(401, "Invalid API key")
+                if split_key[
+                    0
+                ].lower() != "bearer" or not self.provider.authenticate_api_key(
+                    split_key[1], role
+                ):
+                    raise HTTPException(401, "Invalid API key")
 
-    raise HTTPException(401, "Please provide an API key")
+                return authorization
+
+            raise HTTPException(401, "Please provide an API key")
+
+        return check
 
 
-async def check_admin_key(
-    x_admin_key: str = Header(None), authorization: str = Header(None)
-):
-    """Check if the admin key is valid."""
-
-    # Allow request if auth is disabled
-    if DISABLE_AUTH:
-        return
-
-    if x_admin_key:
-        if not AUTH_KEYS.verify_key(x_admin_key, "admin_key"):
-            raise HTTPException(401, "Invalid admin key")
-        return x_admin_key
-
-    if authorization:
-        split_key = authorization.split(" ")
-        if len(split_key) < 2:
-            raise HTTPException(401, "Invalid admin key")
-        if split_key[0].lower() != "bearer" or not AUTH_KEYS.verify_key(
-            split_key[1], "admin_key"
-        ):
-            raise HTTPException(401, "Invalid admin key")
-        return authorization
-
-    raise HTTPException(401, "Please provide an admin key")
+auth = AUTH_PROVIDER_CONTAINER()

--- a/endpoints/Kobold/router.py
+++ b/endpoints/Kobold/router.py
@@ -3,7 +3,7 @@ from fastapi import APIRouter, Depends, Request
 from sse_starlette import EventSourceResponse
 
 from common import model
-from common.auth import check_api_key
+from common.auth import auth, ROLE
 from common.model import check_model_container
 from common.utils import unwrap
 from endpoints.core.utils.model import get_current_model
@@ -45,7 +45,10 @@ def setup():
 
 @kai_router.post(
     "/generate",
-    dependencies=[Depends(check_api_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 async def generate(request: Request, data: GenerateRequest) -> GenerateResponse:
     response = await get_generation(data, request)
@@ -55,7 +58,10 @@ async def generate(request: Request, data: GenerateRequest) -> GenerateResponse:
 
 @extra_kai_router.post(
     "/generate/stream",
-    dependencies=[Depends(check_api_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 async def generate_stream(request: Request, data: GenerateRequest) -> GenerateResponse:
     response = EventSourceResponse(stream_generation(data, request), ping=maxsize)
@@ -65,7 +71,10 @@ async def generate_stream(request: Request, data: GenerateRequest) -> GenerateRe
 
 @extra_kai_router.post(
     "/abort",
-    dependencies=[Depends(check_api_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 async def abort_generate(data: AbortRequest) -> AbortResponse:
     response = await abort_generation(data.genkey)
@@ -75,11 +84,17 @@ async def abort_generate(data: AbortRequest) -> AbortResponse:
 
 @extra_kai_router.get(
     "/generate/check",
-    dependencies=[Depends(check_api_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 @extra_kai_router.post(
     "/generate/check",
-    dependencies=[Depends(check_api_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 async def check_generate(data: CheckGenerateRequest) -> GenerateResponse:
     response = await generation_status(data.genkey)
@@ -88,7 +103,11 @@ async def check_generate(data: CheckGenerateRequest) -> GenerateResponse:
 
 
 @kai_router.get(
-    "/model", dependencies=[Depends(check_api_key), Depends(check_model_container)]
+    "/model",
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 async def current_model() -> CurrentModelResponse:
     """Fetches the current model and who owns it."""
@@ -99,7 +118,10 @@ async def current_model() -> CurrentModelResponse:
 
 @extra_kai_router.post(
     "/tokencount",
-    dependencies=[Depends(check_api_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 async def get_tokencount(data: TokenCountRequest) -> TokenCountResponse:
     raw_tokens = model.container.encode_tokens(data.prompt)
@@ -109,15 +131,24 @@ async def get_tokencount(data: TokenCountRequest) -> TokenCountResponse:
 
 @kai_router.get(
     "/config/max_length",
-    dependencies=[Depends(check_api_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 @kai_router.get(
     "/config/max_context_length",
-    dependencies=[Depends(check_api_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 @extra_kai_router.get(
     "/true_max_context_length",
-    dependencies=[Depends(check_api_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 async def get_max_length() -> MaxLengthResponse:
     """Fetches the max length of the model."""

--- a/endpoints/OAI/utils/completion.py
+++ b/endpoints/OAI/utils/completion.py
@@ -14,7 +14,7 @@ from typing import List, Union
 from loguru import logger
 
 from common import model
-from common.auth import get_key_permission
+from common.auth import auth, ROLE
 from common.networking import (
     get_generator_error,
     handle_request_disconnect,
@@ -117,7 +117,7 @@ async def load_inline_model(model_name: str, request: Request):
         return
 
     # Inline model loading isn't enabled or the user isn't an admin
-    if not get_key_permission(request) == "admin":
+    if not auth.provider.check_api_key(request).role == ROLE.ADMIN:
         error_message = handle_request_error(
             f"Unable to switch model to {model_name} because "
             + "an admin key isn't provided",

--- a/endpoints/core/router.py
+++ b/endpoints/core/router.py
@@ -1,11 +1,12 @@
 import asyncio
 import pathlib
+from typing import Annotated
 from sys import maxsize
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sse_starlette import EventSourceResponse
 
 from common import model, sampling
-from common.auth import check_admin_key, check_api_key, get_key_permission
+from common.auth import auth, ROLE
 from common.downloader import hf_repo_download
 from common.model import check_embeddings_container, check_model_container
 from common.networking import handle_request_error, run_with_request_disconnect
@@ -53,9 +54,12 @@ async def healthcheck():
 
 
 # Model list endpoint
-@router.get("/v1/models", dependencies=[Depends(check_api_key)])
-@router.get("/v1/model/list", dependencies=[Depends(check_api_key)])
-async def list_models(request: Request) -> ModelList:
+@router.get("/v1/models")
+@router.get("/v1/model/list")
+async def list_models(
+    request: Request,
+    api_key: Annotated[str, Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN))],
+) -> ModelList:
     """
     Lists all models in the model directory.
 
@@ -67,7 +71,7 @@ async def list_models(request: Request) -> ModelList:
 
     draft_model_dir = config.draft_model.get("draft_model_dir")
 
-    if get_key_permission(request) == "admin":
+    if auth.provider.check_api_key(request).role == ROLE.ADMIN:
         models = get_model_list(model_path.resolve(), draft_model_dir)
     else:
         models = await get_current_model_list()
@@ -81,7 +85,10 @@ async def list_models(request: Request) -> ModelList:
 # Currently loaded model endpoint
 @router.get(
     "/v1/model",
-    dependencies=[Depends(check_api_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 async def current_model() -> ModelCard:
     """Returns the currently loaded model."""
@@ -89,7 +96,10 @@ async def current_model() -> ModelCard:
     return get_current_model()
 
 
-@router.get("/v1/model/draft/list", dependencies=[Depends(check_api_key)])
+@router.get(
+    "/v1/model/draft/list",
+    dependencies=[Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN))],
+)
 async def list_draft_models(request: Request) -> ModelList:
     """
     Lists all draft models in the model directory.
@@ -97,7 +107,7 @@ async def list_draft_models(request: Request) -> ModelList:
     Requires an admin key to see all draft models.
     """
 
-    if get_key_permission(request) == "admin":
+    if auth.provider.check_api_key(request).role == ROLE.ADMIN:
         draft_model_dir = unwrap(config.draft_model.get("draft_model_dir"), "models")
         draft_model_path = pathlib.Path(draft_model_dir)
 
@@ -109,7 +119,7 @@ async def list_draft_models(request: Request) -> ModelList:
 
 
 # Load model endpoint
-@router.post("/v1/model/load", dependencies=[Depends(check_admin_key)])
+@router.post("/v1/model/load", dependencies=[Depends(auth.check_api_key(ROLE.ADMIN))])
 async def load_model(data: ModelLoadRequest) -> ModelLoadResponse:
     """Loads a model into the model container. This returns an SSE stream."""
 
@@ -153,14 +163,17 @@ async def load_model(data: ModelLoadRequest) -> ModelLoadResponse:
 # Unload model endpoint
 @router.post(
     "/v1/model/unload",
-    dependencies=[Depends(check_admin_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 async def unload_model():
     """Unloads the currently loaded model."""
     await model.unload_model(skip_wait=True)
 
 
-@router.post("/v1/download", dependencies=[Depends(check_admin_key)])
+@router.post("/v1/download", dependencies=[Depends(auth.check_api_key(ROLE.ADMIN))])
 async def download_model(request: Request, data: DownloadRequest) -> DownloadResponse:
     """Downloads a model from HuggingFace."""
 
@@ -182,8 +195,12 @@ async def download_model(request: Request, data: DownloadRequest) -> DownloadRes
 
 
 # Lora list endpoint
-@router.get("/v1/loras", dependencies=[Depends(check_api_key)])
-@router.get("/v1/lora/list", dependencies=[Depends(check_api_key)])
+@router.get(
+    "/v1/loras", dependencies=[Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN))]
+)
+@router.get(
+    "/v1/lora/list", dependencies=[Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN))]
+)
 async def list_all_loras(request: Request) -> LoraList:
     """
     Lists all LoRAs in the lora directory.
@@ -191,7 +208,7 @@ async def list_all_loras(request: Request) -> LoraList:
     Requires an admin key to see all LoRAs.
     """
 
-    if get_key_permission(request) == "admin":
+    if auth.provider.check_api_key(request).role == ROLE.ADMIN:
         lora_path = pathlib.Path(unwrap(config.lora.get("lora_dir"), "loras"))
         loras = get_lora_list(lora_path.resolve())
     else:
@@ -203,7 +220,10 @@ async def list_all_loras(request: Request) -> LoraList:
 # Currently loaded loras endpoint
 @router.get(
     "/v1/lora",
-    dependencies=[Depends(check_api_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 async def active_loras() -> LoraList:
     """Returns the currently loaded loras."""
@@ -214,7 +234,10 @@ async def active_loras() -> LoraList:
 # Load lora endpoint
 @router.post(
     "/v1/lora/load",
-    dependencies=[Depends(check_admin_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 async def load_lora(data: LoraLoadRequest) -> LoraLoadResponse:
     """Loads a LoRA into the model container."""
@@ -249,7 +272,10 @@ async def load_lora(data: LoraLoadRequest) -> LoraLoadResponse:
 # Unload lora endpoint
 @router.post(
     "/v1/lora/unload",
-    dependencies=[Depends(check_admin_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 async def unload_loras():
     """Unloads the currently loaded loras."""
@@ -257,7 +283,10 @@ async def unload_loras():
     await model.unload_loras()
 
 
-@router.get("/v1/model/embedding/list", dependencies=[Depends(check_api_key)])
+@router.get(
+    "/v1/model/embedding/list",
+    dependencies=[Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN))],
+)
 async def list_embedding_models(request: Request) -> ModelList:
     """
     Lists all embedding models in the model directory.
@@ -265,7 +294,7 @@ async def list_embedding_models(request: Request) -> ModelList:
     Requires an admin key to see all embedding models.
     """
 
-    if get_key_permission(request) == "admin":
+    if auth.provider.check_api_key(request).role == ROLE.ADMIN:
         embedding_model_dir = unwrap(
             config.embeddings.get("embedding_model_dir"), "models"
         )
@@ -280,7 +309,10 @@ async def list_embedding_models(request: Request) -> ModelList:
 
 @router.get(
     "/v1/model/embedding",
-    dependencies=[Depends(check_api_key), Depends(check_embeddings_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN)),
+        Depends(check_embeddings_container),
+    ],
 )
 async def get_embedding_model() -> ModelCard:
     """Returns the currently loaded embedding model."""
@@ -289,7 +321,9 @@ async def get_embedding_model() -> ModelCard:
     return models.data[0]
 
 
-@router.post("/v1/model/embedding/load", dependencies=[Depends(check_admin_key)])
+@router.post(
+    "/v1/model/embedding/load", dependencies=[Depends(auth.check_api_key(ROLE.ADMIN))]
+)
 async def load_embedding_model(
     request: Request, data: EmbeddingModelLoadRequest
 ) -> ModelLoadResponse:
@@ -337,7 +371,10 @@ async def load_embedding_model(
 
 @router.post(
     "/v1/model/embedding/unload",
-    dependencies=[Depends(check_admin_key), Depends(check_embeddings_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.ADMIN)),
+        Depends(check_embeddings_container),
+    ],
 )
 async def unload_embedding_model():
     """Unloads the current embedding model."""
@@ -348,7 +385,10 @@ async def unload_embedding_model():
 # Encode tokens endpoint
 @router.post(
     "/v1/token/encode",
-    dependencies=[Depends(check_api_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 async def encode_tokens(data: TokenEncodeRequest) -> TokenEncodeResponse:
     """Encodes a string or chat completion messages into tokens."""
@@ -378,7 +418,10 @@ async def encode_tokens(data: TokenEncodeRequest) -> TokenEncodeResponse:
 # Decode tokens endpoint
 @router.post(
     "/v1/token/decode",
-    dependencies=[Depends(check_api_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 async def decode_tokens(data: TokenDecodeRequest) -> TokenDecodeResponse:
     """Decodes tokens into a string."""
@@ -389,7 +432,10 @@ async def decode_tokens(data: TokenDecodeRequest) -> TokenDecodeResponse:
     return response
 
 
-@router.get("/v1/auth/permission", dependencies=[Depends(check_api_key)])
+@router.get(
+    "/v1/auth/permission",
+    dependencies=[Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN))],
+)
 async def key_permission(request: Request) -> AuthPermissionResponse:
     """
     Gets the access level/permission of a provided key in headers.
@@ -409,8 +455,13 @@ async def key_permission(request: Request) -> AuthPermissionResponse:
         raise HTTPException(400, error_message) from exc
 
 
-@router.get("/v1/templates", dependencies=[Depends(check_api_key)])
-@router.get("/v1/template/list", dependencies=[Depends(check_api_key)])
+@router.get(
+    "/v1/templates", dependencies=[Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN))]
+)
+@router.get(
+    "/v1/template/list",
+    dependencies=[Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN))],
+)
 async def list_templates(request: Request) -> TemplateList:
     """
     Get a list of all templates.
@@ -419,7 +470,7 @@ async def list_templates(request: Request) -> TemplateList:
     """
 
     template_strings = []
-    if get_key_permission(request) == "admin":
+    if auth.provider.check_api_key(request).role == ROLE.ADMIN:
         templates = get_all_templates()
         template_strings = [template.stem for template in templates]
     else:
@@ -431,7 +482,10 @@ async def list_templates(request: Request) -> TemplateList:
 
 @router.post(
     "/v1/template/switch",
-    dependencies=[Depends(check_admin_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 async def switch_template(data: TemplateSwitchRequest):
     """Switch the currently loaded template."""
@@ -457,7 +511,10 @@ async def switch_template(data: TemplateSwitchRequest):
 
 @router.post(
     "/v1/template/unload",
-    dependencies=[Depends(check_admin_key), Depends(check_model_container)],
+    dependencies=[
+        Depends(auth.check_api_key(ROLE.ADMIN)),
+        Depends(check_model_container),
+    ],
 )
 async def unload_template():
     """Unloads the currently selected template"""
@@ -466,8 +523,14 @@ async def unload_template():
 
 
 # Sampler override endpoints
-@router.get("/v1/sampling/overrides", dependencies=[Depends(check_api_key)])
-@router.get("/v1/sampling/override/list", dependencies=[Depends(check_api_key)])
+@router.get(
+    "/v1/sampling/overrides",
+    dependencies=[Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN))],
+)
+@router.get(
+    "/v1/sampling/override/list",
+    dependencies=[Depends(auth.check_api_key(ROLE.USER | ROLE.ADMIN))],
+)
 async def list_sampler_overrides(request: Request) -> SamplerOverrideListResponse:
     """
     List all currently applied sampler overrides.
@@ -475,7 +538,7 @@ async def list_sampler_overrides(request: Request) -> SamplerOverrideListRespons
     Requires an admin key to see all override presets.
     """
 
-    if get_key_permission(request) == "admin":
+    if auth.provider.check_api_key(request).role == ROLE.ADMIN:
         presets = sampling.get_all_presets()
     else:
         presets = []
@@ -487,7 +550,7 @@ async def list_sampler_overrides(request: Request) -> SamplerOverrideListRespons
 
 @router.post(
     "/v1/sampling/override/switch",
-    dependencies=[Depends(check_admin_key)],
+    dependencies=[Depends(auth.check_api_key(ROLE.ADMIN))],
 )
 async def switch_sampler_override(data: SamplerOverrideSwitchRequest):
     """Switch the currently loaded override preset"""
@@ -516,7 +579,7 @@ async def switch_sampler_override(data: SamplerOverrideSwitchRequest):
 
 @router.post(
     "/v1/sampling/override/unload",
-    dependencies=[Depends(check_admin_key)],
+    dependencies=[Depends(auth.check_api_key(ROLE.ADMIN))],
 )
 async def unload_sampler_override():
     """Unloads the currently selected override preset"""

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 from common import gen_logging, sampling, model
 from common.args import convert_args_to_dict, init_argparser
-from common.auth import load_auth_keys
+from common.auth import auth
 from common.logger import setup_logger
 from common.networking import is_port_in_use
 from common.signals import signal_handler
@@ -50,7 +50,7 @@ async def entrypoint_async():
             port = fallback_port
 
     # Initialize auth keys
-    load_auth_keys(unwrap(config.network.get("disable_auth"), False))
+    auth.load(unwrap(config.network.get("disable_auth"), False))
 
     # Override the generation log options if given
     if config.logging:


### PR DESCRIPTION
This PR adds:
- RBAC support
- support for multiple API keys

Backwards compatibility with existing files is maintained though they should be marked as deprecated.

fixes #79 