### PR TITLE
debloat docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+.ruff_cache/
+**/__pycache__/
+venv
+.git
+.gitignore
+.github
+
+# Ignore specific application files
+models/
+loras/
+config.yml
+config_sample.yml
+api_tokens.yml
+api_tokens_sample.yml
+*.bat
+*.sh
+update_scripts
+readme.md
+colab
+start.py

--- a/docker/.dockerignore
+++ b/docker/.dockerignore
@@ -1,6 +1,0 @@
-models/
-loras/
-.ruff_cache/
-**/__pycache__/
-config.yml
-api_tokens.yml

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,6 +22,8 @@ COPY pyproject.toml .
 # Install packages specified in pyproject.toml cu121
 RUN pip3 install --no-cache-dir .[cu121]
 
+RUN rm pyproject.toml
+
 # Copy the current directory contents into the container
 COPY . .
 


### PR DESCRIPTION
**Why should this feature be added?**
- decrease container size
- decrease potential attack surfaces
- faster build time

**Examples**
tests are not required in a production container
