### PR TITLE
add static type checker to dev environment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ extras = [
     "sentence-transformers",
 ]
 dev = [
-    "ruff == 0.3.2"
+    "ruff == 0.3.2",
+    "mypy",
 ]
 cu121 = [
     # Torch (Extra index URLs not support in pyproject.toml)

--- a/static_analysis.bat
+++ b/static_analysis.bat
@@ -1,0 +1,11 @@
+@echo off
+
+:: check if less is installed
+:: run scoop install less
+:: https://scoop.sh/#/apps?q=less&id=e084d861765203aae2d64ada4e59ef350df0f25b
+where less >nul 2>&1
+if %errorlevel%==0 (
+    mypy start.py | less
+) else (
+    mypy start.py
+)

--- a/static_analysis.sh
+++ b/static_analysis.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if command -v less > /dev/null 2>&1; then
+    mypy start.py | less
+else
+    mypy start.py
+fi


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
Currently there is a good chance to make mistakes when contributing new code, for example the invalid arguments in #191, which could have easily been caught before making its way into the production build using static analysis

**Why should this feature be added?**
This feature will work directly to reduce the amount of bugs in the code and drastically help with refactoring code. Here are some example issues that it detected when I was testing the scripts:

endpoints\OAI\utils\embeddings.py:64: error: Incompatible return value type (got "EmbeddingsResponse", expected "dict[Any, Any]")  [return-value]
endpoints\Kobold\router.py:126: error: Incompatible return value type (got "dict[str, Any]", expected "MaxLengthResponse")  [return-value]

**Examples**
see #191 

**Additional context**
moving the config to pydantic as in #189 would expand the functionality in this to prevent issues like #104