### PR TITLE
Properly specify config "inline_model_loading" value in the error message

### DIFF
--- a/endpoints/OAI/utils/completion.py
+++ b/endpoints/OAI/utils/completion.py
@@ -129,7 +129,7 @@ async def load_inline_model(model_name: str, request: Request):
     if not unwrap(config.model.get("inline_model_loading"), False):
         logger.warning(
             f"Unable to switch model to {model_name} because "
-            '"inline_model_load" is not True in config.yml.'
+            '"inline_model_loading" is not True in config.yml.'
         )
 
         return


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
In the exception text, "inline_model_load" should instead spell "inline_model_loading".

**Why should this feature be added?**
Invalid config references confuses the user.

**Examples**
Try to load the model without "inline_model_loading" set to true. Observe the error.

**Additional context**
None.