### PR TITLE
Add health check monitoring for EXL2 errors

### DIFF
--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -32,6 +32,8 @@ from typing import List, Optional, Union
 
 from ruamel.yaml import YAML
 
+from common.health import HealthManager
+
 from backends.exllamav2.grammar import (
     ExLlamaV2Grammar,
     clear_grammar_func_cache,
@@ -1372,6 +1374,8 @@ class ExllamaV2Container:
                 "If this fails, please restart the server.\n"
             )
             asyncio.ensure_future(self.create_generator())
+
+            await HealthManager.add_unhealthy_event(ex)
 
             raise ex
         finally:

--- a/common/health.py
+++ b/common/health.py
@@ -1,9 +1,9 @@
 import asyncio
-from typing import Union
-from pydantic import BaseModel, Field
-from datetime import datetime, timezone
 from collections import deque
+from datetime import datetime, timezone
 from functools import partial
+from pydantic import BaseModel, Field
+from typing import Union
 
 
 class UnhealthyEvent(BaseModel):

--- a/common/health.py
+++ b/common/health.py
@@ -1,0 +1,42 @@
+import asyncio
+from typing import Union
+from pydantic import BaseModel, Field
+from datetime import datetime, timezone
+from collections import deque
+from functools import partial
+
+
+class UnhealthyEvent(BaseModel):
+    """Represents an error that makes the system unhealthy"""
+
+    time: datetime = Field(
+        default_factory=partial(datetime.now, timezone.utc),
+        description="Time the error occurred in UTC time",
+    )
+    description: str = Field("Unknown error", description="The error message")
+
+
+class HealthManagerClass:
+    """Class to manage the health global state"""
+
+    def __init__(self):
+        # limit the max stored errors to 100 to avoid a memory leak
+        self.issues: deque[UnhealthyEvent] = deque(maxlen=100)
+        self._lock = asyncio.Lock()
+
+    async def add_unhealthy_event(self, error: Union[str, Exception]):
+        """Add a new unhealthy event"""
+        async with self._lock:
+            if isinstance(error, Exception):
+                error = f"{error.__class__.__name__}: {str(error)}"
+            self.issues.append(UnhealthyEvent(description=error))
+
+    async def is_service_healthy(self) -> tuple[bool, list[UnhealthyEvent]]:
+        """Check if the service is healthy"""
+        async with self._lock:
+            healthy = len(self.issues) == 0
+            return healthy, list(self.issues)
+
+
+# Create an instance of the global state manager
+HealthManager = HealthManagerClass()

--- a/endpoints/core/router.py
+++ b/endpoints/core/router.py
@@ -54,7 +54,7 @@ async def healthcheck(response: Response) -> HealthCheckResponse:
     healthy, issues = await HealthManager.is_service_healthy()
 
     if not healthy:
-        response.status_code = 500
+        response.status_code = 503
 
     return HealthCheckResponse(
         status="healthy" if healthy else "unhealthy", issues=issues

--- a/endpoints/core/types/health.py
+++ b/endpoints/core/types/health.py
@@ -1,0 +1,15 @@
+from typing import Literal
+from pydantic import BaseModel, Field
+
+from common.health import UnhealthyEvent
+
+
+class HealthCheckResponse(BaseModel):
+    """System health status"""
+
+    status: Literal["healthy", "unhealthy"] = Field(
+        "healthy", description="System health status"
+    )
+    issues: list[UnhealthyEvent] = Field(
+        default_factory=list, description="List of issues"
+    )


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
Recently when hibernating my PC I experienced the model unloading and tabbyAPI getting itself stuck reloading the EXL2 container every request.

**Why should this feature be added?**
This issue adds an internal logging system for fatal errors and code to auto generate a response for the health check endpoint so that it is possible to automatically restart the program if this happens again and fix the error

**Examples**
The health check endpoint returns 200 OK and status healthy on my machine even when every request is responded to with an error. This would fix that. 

**Additional context**
In the future it will be possible to expand this system easily if more possible fatal errors are discovered by adding a statement to register them in the health manager singleton. 