### PR TITLE
Fix draft model non-FA2 fallback

### DIFF
--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -159,7 +159,6 @@ class ExllamaV2Container:
 
         if enable_draft:
             self.draft_config = ExLlamaV2Config()
-            self.draft_config.no_flash_attn = self.config.no_flash_attn
             draft_model_path = pathlib.Path(
                 unwrap(draft_args.get("draft_model_dir"), "models")
             )
@@ -253,6 +252,8 @@ class ExllamaV2Container:
             or not supports_paged_attn()
         ):
             self.config.no_flash_attn = True
+            if self.draft_config:
+                self.draft_config.no_flash_attn = True
             self.paged = False
             self.max_batch_size = 1
             torch.backends.cuda.enable_flash_sdp(False)


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
Fixes https://github.com/theroyallab/tabbyAPI/issues/238

**Why should this feature be added?**
N/A

**Examples**
N/A

**Additional context**
Flash attention was not being disabled for the draft model after being determined to be unavailable/incompatible.
