### PR TITLE
workaround for tool calling

### DIFF
--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -454,11 +454,11 @@ async def generate_tool_calls(
         if gen["stop_str"] in tool_data.tool_call_start:
             if "text" in gen:
                 # non streaming, all generations will have the text they generated
-                pre_tool_prompt = await apply_chat_template(data, gen["text"])
+                pre_tool_prompt, _ = await apply_chat_template(data, gen["text"])
             elif current_generations is not None:
                 # streaming, we wont have text in the generation,
                 # we'll have to use the current_generations
-                pre_tool_prompt = await apply_chat_template(data, current_generations)
+                pre_tool_prompt, _ = await apply_chat_template(data, current_generations)
 
             gen_tasks.append(
                 asyncio.create_task(

--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -454,16 +454,23 @@ async def generate_tool_calls(
         if gen["stop_str"] in tool_data.tool_call_start:
             if "text" in gen:
                 # non streaming, all generations will have the text they generated
-                pre_tool_prompt, _ = await apply_chat_template(data, gen["text"])
+                pre_tool_prompt, mm_embeddings = await apply_chat_template(
+                    data, gen["text"]
+                )
             elif current_generations is not None:
                 # streaming, we wont have text in the generation,
                 # we'll have to use the current_generations
-                pre_tool_prompt, _ = await apply_chat_template(data, current_generations)
+                pre_tool_prompt, mm_embeddings = await apply_chat_template(
+                    data, current_generations
+                )
 
             gen_tasks.append(
                 asyncio.create_task(
                     model.container.generate(
-                        pre_tool_prompt, request.state.id, **gen_params
+                        pre_tool_prompt,
+                        request.state.id,
+                        embeddings=mm_embeddings,
+                        **gen_params,
                     )
                 )
             )


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
Related to #234.

**Why should this feature be added?**
Not a proper fix, but could be merged into a local branch if anyone needs a quick workaround.

**Examples**
Enables tool calling again. However, it still raises an error when combined with draft models. To work around that background_drop should be called early. I'm having a hard time understanding the code in the time I have, and SD+TC is probably only wanted by a few people, so this is all I have for now.

**Additional context**
I tried disabling the draft model just before generating the prompt for the tool call (mainly to not have to relaunch TabbyAPI to switch from using a draft for coding and back to using tool calling), but I got into a tool call loop. That's not the way to fix this anyway.
