### PR TITLE
add draft_gpu_split option for spec decoding

### DIFF
--- a/common/config_models.py
+++ b/common/config_models.py
@@ -351,6 +351,13 @@ class DraftModelConfig(BaseConfigModel):
             f"Possible values: {str(CACHE_SIZES)[15:-1]}."
         ),
     )
+    draft_gpu_split: List[float] = Field(
+        default_factory=list,
+        description=(
+            "An integer array of GBs of VRAM to split between GPUs (default: []).\n"
+            "If this isn't filled in, the draft model is autosplit."
+        ),
+    )
 
 
 class LoraInstanceModel(BaseConfigModel):

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -20,7 +20,7 @@ network:
   # Turn on this option if you are ONLY connecting from localhost.
   disable_auth: false
 
-  # Disable fetching external content in response to requests, such as images from URLs.
+  # Disable fetching external content in response to requests,such as images from URLs.
   disable_fetch_requests: false
 
   # Send tracebacks over the API (default: False).
@@ -165,6 +165,10 @@ draft_model:
   # Cache mode for draft models to save VRAM (default: FP16).
   # Possible values: 'FP16', 'Q8', 'Q6', 'Q4'.
   draft_cache_mode: FP16
+
+  # An integer array of GBs of VRAM to split between GPUs (default: []).
+  # If this isn't filled in, the draft model is autosplit.
+  draft_gpu_split: []
 
 # Options for Loras
 lora:


### PR DESCRIPTION
with a setup of 3090+3060; loading 32b (5bpw) and 1.5b or 0.5b draft (6bpw) first loads the draft model and then the model; making an otherwise 32b fitting onto the single 3090 (a lot more bandwidth) leak onto the 3060 with quite a few layers, negating all benefits of the draft model and even dropping performance even more (15-30% less tps); now pinning the draft model to another gpu (the 3060) entirely bypasses that and you get the same performance boost for spec decoding as before.

tabby_config.yml example of a draft_gpu_split:

![image](https://github.com/user-attachments/assets/175ea167-6f71-4898-b6f1-205823dc1a13)

I have tested it both with autosplit on the target model and manually splitting via gpu_split, the gpu-split syntax stays the same to be able to re-use the same code.

this is merely a kick-off PR to make it work, as I'm not sure if there's anything else that needs to be modified for this to be upstreamable and if there's some neat python tricks to not have to duplicate code in e.g. initializing gpu_device_list.