### PR TITLE
Fix import for sse_starlette v2.2.0, pin version

### DIFF
--- a/endpoints/Kobold/utils/generation.py
+++ b/endpoints/Kobold/utils/generation.py
@@ -2,7 +2,7 @@ import asyncio
 from asyncio import CancelledError
 from fastapi import HTTPException, Request
 from loguru import logger
-from sse_starlette import ServerSentEvent
+from sse_starlette.event import ServerSentEvent
 
 from common import model
 from common.networking import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "uvicorn >= 0.28.1",
     "jinja2 >= 3.0.0",
     "loguru",
-    "sse-starlette",
+    "sse-starlette >= 2.2.0",
     "packaging",
     "tokenizers>=0.21.0",
     "formatron",


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
https://github.com/sysid/sse-starlette/commit/d05601edaa0d1796d52f70b9be7fa42b6a7320e8 moved the `ServerSentEvent` class to a different file, causing import to fail.

**Why should this feature be added?**
N/A

**Examples**
N/A

**Additional context**
N/A
