### PR TITLE
Bump formatron to `0.4.11`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "sse-starlette >= 2.2.0",
     "packaging",
     "tokenizers >= 0.21.0",
-    "formatron >= 0.4.10",
+    "formatron >= 0.4.11",
     "kbnf >= 0.4.1",
     "aiofiles",
     "aiohttp",


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
Fixes issue with tool calling, where a completion request was always crashing due to:
```
"/usr/local/lib/python3.10/dist-packages/formatron/formatter.py", line 388, in
to_json
ERROR:        if isinstance(schema, type) and issubclass(schema, Schema):
ERROR:      File "/usr/lib/python3.10/abc.py", line 123, in __subclasscheck__
ERROR:        return _abc_subclasscheck(cls, subclass)
ERROR:    TypeError: issubclass() arg 1 must be a clas
```
It was fixed (thanks @Dan-wanna-M) in [this commit](https://github.com/Dan-wanna-M/formatron/commit/4dc156fc9d6e30add389f34fc37ced9011fc8805).

**Why should this feature be added?**
N/A

**Examples**
N/A

**Additional context**
N/A
