### PR TITLE
Fix the OpenAI finish_reason for tool use

### DIFF
--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -50,6 +50,7 @@ def _create_response(
         tool_calls = generation["tool_calls"]
         if tool_calls:
             message.tool_calls = postprocess_tool_call(tool_calls)
+            logger.info(f"Tool Calls Generated\n-----------------\n{message.tool_calls}\n-----------------") # TODO: Remove
 
         logprob_response = None
 
@@ -297,9 +298,11 @@ async def apply_chat_template(
             }
         )
 
+        logger.info(f"Template_VARS:\n-------------------\n{data.template_vars}\n-----------------") # TODO: Remove
         prompt, mm_embeddings, template_vars = await format_messages_with_template(
             data.messages, data.template_vars, data.add_bos_token, data.ban_eos_token
         )
+        logger.info(f"Prompt:\n-------------------\n{prompt}\n-----------------") # TODO: Remove
 
         # Append response prefix if present
         if data.response_prefix:

--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -465,6 +465,7 @@ async def generate_chat_completion(
         if data.tool_call_start:
             generations = await generate_tool_calls(data, generations, request)
 
+        logger.info*f"generate_chat_completion.generations: -----------------------\n{generations}\n---------------"
         response = _create_response(request.state.id, generations, model_path.name)
 
         logger.info(f"Finished chat completion request {request.state.id}")
@@ -503,13 +504,14 @@ async def generate_tool_calls(
                 pre_tool_prompt, mm_embeddings = await apply_chat_template(
                     data, gen["text"]
                 )
+                logger.info(f"Pre Tool Prompt [text]: ------------------\n{pre_tool_prompt}\n----------------------")
             elif current_generations is not None:
                 # streaming, we wont have text in the generation,
                 # we'll have to use the current_generations
                 pre_tool_prompt, mm_embeddings = await apply_chat_template(
                     data, current_generations
                 )
-
+                logger.info(f"Pre Tool Prompt [other]: ------------------\n{pre_tool_prompt}\n----------------------")
             gen_tasks.append(
                 asyncio.create_task(
                     model.container.generate(

--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -465,7 +465,7 @@ async def generate_chat_completion(
         if data.tool_call_start:
             generations = await generate_tool_calls(data, generations, request)
 
-        logger.info*f"generate_chat_completion.generations: -----------------------\n{generations}\n---------------"
+        logger.info(f"generate_chat_completion.generations: -----------------------\n{generations}\n---------------")
         response = _create_response(request.state.id, generations, model_path.name)
 
         logger.info(f"Finished chat completion request {request.state.id}")

--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -134,10 +134,7 @@ def _create_stream_chunk(
     elif "finish_reason" in generation:
         # Get the finish reason from the generation
         finish_reason = generation.get("finish_reason")
-        choice = ChatCompletionStreamChoice(
-            index=index,
-            finish_reason=finish_reason
-        )
+        choice = ChatCompletionStreamChoice(index=index, finish_reason=finish_reason)
 
         # lets check if we have tool calls since we are at the end of the generation
         if "tool_calls" in generation:


### PR DESCRIPTION

**Is your pull request related to a problem? Please describe.**
It appears as though TabbyAPI is not returning the proper finish_reason in the OpenAI endpoints when handling tool use. The OpenAI sets the "finish_reason": "tool_calls" if any tools are used, but the current TabbyAPI implementation will return "stop", which breaks OpenAI clients.

The only change I made was if there is a finish_reason (not None), and there are tool_calls, then set the finish_reason to "tool_calls" in accordance with the OpenAI api behavior.


**Why should this feature be added?**
An explanation of why the feature should be added. Please be as specific as possible to help us understand the reasoning.

**Examples**

Example of Original (Incorrect) finish reason behavior: Notice the finish_reason as "stop"
```
{"id":"chatcmpl-4c264611c1ae45bdbccb4129cb3030c8","choices":[{"index":0,"finish_reason":"stop","stop_str":"<function=","message":{"role":"assistant","content":"","tool_calls":[{"id":"tool_id_1342","function":{"name":"execute_services","arguments":"{\"list\": [{\"domain\": \"light\", \"service\": \"turn_off\", \"service_data\": {\"entity_id\": \"light.office_lights\"}}]}"},"type":"function"}],"tool_calls_json":null},"logprobs":null}],"created":1740159686,"model":"watt-homeassistant-llama-8b-4bpw-8k","object":"chat.completion","usage":{"prompt_tokens":1400,"completion_tokens":1,"total_tokens":1401}}
```

Example of New (Correct) finish reason behavior: Notice the finish_reason as "tool_calls"
```
{"id":"chatcmpl-15a76a174e194b8ea08c864d1199e86a","choices":[{"index":0,"finish_reason":"tool_calls","stop_str":"<function=","message":{"role":"assistant","content":"","tool_calls":[{"id":"tool_id_1342","function":{"name":"execute_services","arguments":"{\"list\": [{\"domain\": \"light\", \"service\": \"turn_off\", \"service_data\": {\"entity_id\": \"light.office_lights\"}}]}"},"type":"function"}],"tool_calls_json":null},"logprobs":null}],"created":1740164277,"model":"watt-homeassistant-llama-8b-4bpw-8k","object":"chat.completion","usage":{"prompt_tokens":1400,"completion_tokens":1,"total_tokens":1401}}```

**Additional context**
Add any other context or screenshots about the pull request here.
