### PR TITLE
Bug fix finish reason in openai tool call choice

### DIFF
--- a/common/logger.py
+++ b/common/logger.py
@@ -115,3 +115,14 @@ def setup_logger():
         format=_log_formatter,
         colorize=True,
     )
+
+
+    # Add file logging
+    logger.add(
+        "/var/log/tabbyapi/{time}.log",  # This will create the file in the project root
+        level=LOG_LEVEL,
+        format="{time:YYYY-MM-DD HH:mm:ss.SSS} | {level: <8} | {message}",
+        rotation="20 MB",  # Rotate file when it reaches 10MB
+        retention="1 week",  # Keep logs for 1 week
+        compression="zip",  # Compress rotated logs
+    )

--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -134,10 +134,7 @@ def _create_stream_chunk(
     elif "finish_reason" in generation:
         # Get the finish reason from the generation
         finish_reason = generation.get("finish_reason")
-        choice = ChatCompletionStreamChoice(
-            index=index,
-            finish_reason=finish_reason
-        )
+        choice = ChatCompletionStreamChoice(index=index, finish_reason=finish_reason)
 
         # lets check if we have tool calls since we are at the end of the generation
         if "tool_calls" in generation:


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
It appears as though TabbyAPI is not returning the proper finish_reason in the OpenAI endpoints when handling tool use. The OpenAI sets the "finish_reason": "tool_calls" if any tools are used, but the current TabbyAPI implementation will return "stop", which breaks OpenAI clients.

The only change I made was if there is a finish_reason (not None), and there are tool_calls, then set the finish_reason to "tool_calls" in accordance with the OpenAI api behavior.


**Why should this feature be added?**
An explanation of why the feature should be added. Please be as specific as possible to help us understand the reasoning.

**Examples**

Example of Original (Incorrect) finish reason behavior: Notice the finish_reason as "stop"
```
{"id":"chatcmpl-4c264611c1ae45bdbccb4129cb3030c8","choices":[{"index":0,"finish_reason":"stop","stop_str":"<function=","message":{"role":"assistant","content":"","tool_calls":[{"id":"tool_id_1342","function":{"name":"execute_services","arguments":"{\"list\": [{\"domain\": \"light\", \"service\": \"turn_off\", \"service_data\": {\"entity_id\": \"light.office_lights\"}}]}"},"type":"function"}],"tool_calls_json":null},"logprobs":null}],"created":1740159686,"model":"watt-homeassistant-llama-8b-4bpw-8k","object":"chat.completion","usage":{"prompt_tokens":1400,"completion_tokens":1,"total_tokens":1401}}
```

Example of New (Correct) finish reason behavior: Notice the finish_reason as "tool_calls"
```
{"id":"chatcmpl-15a76a174e194b8ea08c864d1199e86a","choices":[{"index":0,"finish_reason":"tool_calls","stop_str":"<function=","message":{"role":"assistant","content":"","tool_calls":[{"id":"tool_id_1342","function":{"name":"execute_services","arguments":"{\"list\": [{\"domain\": \"light\", \"service\": \"turn_off\", \"service_data\": {\"entity_id\": \"light.office_lights\"}}]}"},"type":"function"}],"tool_calls_json":null},"logprobs":null}],"created":1740164277,"model":"watt-homeassistant-llama-8b-4bpw-8k","object":"chat.completion","usage":{"prompt_tokens":1400,"completion_tokens":1,"total_tokens":1401}}```

**Additional context**
Add any other context or screenshots about the pull request here.
