### PR TITLE
:sparkles: reasoning parser support

### DIFF
--- a/common/config_models.py
+++ b/common/config_models.py
@@ -99,6 +99,27 @@ class NetworkConfig(BaseConfigModel):
             "Possible values: OAI, Kobold."
         ),
     )
+    reasoning_parser: bool = Field(
+        False,
+        description=(
+            "Enable the reasoning parser (default: False).\n"
+            "This will split response message into reasoning_content and content fields."
+        )
+    )
+    reasoning_start_token: str = Field(
+        "<think>",
+        description=(
+            "Start token for the reasoning parser (default: <think>).\n"
+            "This token is used to split the response message into reasoning_content and content fields."
+        )
+    )
+    reasoning_end_token: str = Field(
+        "</think>",
+        description=(
+            "End token for the reasoning parser (default: </think>).\n"
+            "This token is used to split the response message into reasoning_content and content fields."
+        )
+    )
 
     # Converts all strings in the api_servers list to lowercase
     # NOTE: Expand if more models need this validator

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -31,6 +31,16 @@ network:
   # Possible values: OAI, Kobold.
   api_servers: ["OAI"]
 
+  # Enable reasoning parser (default: False).
+  # Do NOT enable this if the model is not a reasoning model (e.g. deepseek-r1 series)
+  reasoning_parser: false
+
+  # The start token for reasoning conetnt (default: "<think>")
+  reasoning_start_token: "<think>"
+
+  # The end token for reasoning conetnt (default: "</think>")
+  reasoning_end_token: "</think>"
+
 # Options for logging
 logging:
   # Enable prompt logging (default: False).

--- a/endpoints/OAI/types/chat_completion.py
+++ b/endpoints/OAI/types/chat_completion.py
@@ -31,6 +31,7 @@ class ChatCompletionMessagePart(BaseModel):
 class ChatCompletionMessage(BaseModel):
     role: str = "user"
     content: Optional[Union[str, List[ChatCompletionMessagePart]]] = None
+    reasoning_content: Optional[str] = None
     tool_calls: Optional[List[ToolCall]] = None
     tool_calls_json: SkipJsonSchema[Optional[str]] = None
 

--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -17,6 +17,7 @@ from common.networking import (
     handle_request_error,
     request_disconnect_loop,
 )
+from common.tabby_config import config
 from common.utils import unwrap
 from endpoints.OAI.types.chat_completion import (
     ChatCompletionLogprobs,
@@ -33,6 +34,20 @@ from endpoints.OAI.utils.completion import _stream_collector
 from endpoints.OAI.types.tools import ToolCall
 
 
+def _extract_think_content(text: str) -> tuple[Optional[str], Optional[str]]:
+    """Extract content between <think> tags and the remaining content. Only available in none-streaming mode."""
+    if config.network.reasoning_start_token not in text and config.network.reasoning_end_token not in text:
+        return None, text
+    elif config.network.reasoning_start_token in text:
+        start_reasoning = text.split(config.network.reasoning_start_token)[1]
+        reasoning_content = start_reasoning.split(config.network.reasoning_end_token)[0]
+        content = start_reasoning.split(config.network.reasoning_end_token)[1]
+        return reasoning_content, content
+    else:
+        reasoning_content = text.split(config.network.reasoning_end_token)[0]
+        content = text.split(config.network.reasoning_end_token)[1]
+        return reasoning_content, content
+
 def _create_response(
     request_id: str, generations: List[dict], model_name: Optional[str]
 ):
@@ -43,9 +58,16 @@ def _create_response(
 
     choices = []
     for index, generation in enumerate(generations):
-        message = ChatCompletionMessage(
-            role="assistant", content=unwrap(generation.get("text"), "")
-        )
+        if config.network.reasoning_parser:
+            raw_content = unwrap(generation.get("text"), "")
+            reasoning_content, content = _extract_think_content(raw_content)
+            message = ChatCompletionMessage(
+                role="assistant", reasoning_content=reasoning_content, content=content
+            )
+        else:
+            message = ChatCompletionMessage(
+                role="assistant", content=unwrap(generation.get("text"), "")
+            )
 
         tool_calls = generation["tool_calls"]
         if tool_calls:
@@ -103,6 +125,7 @@ def _create_stream_chunk(
     generation: Optional[dict] = None,
     model_name: Optional[str] = None,
     is_usage_chunk: bool = False,
+    is_reasoning_chunk: bool = False,
 ):
     """Create a chat completion stream chunk from the provided text."""
 
@@ -137,6 +160,8 @@ def _create_stream_chunk(
 
     else:
         message = ChatCompletionMessage(
+            role="assistant", reasoning_content=unwrap(generation.get("text"), "")
+        ) if is_reasoning_chunk else ChatCompletionMessage(
             role="assistant", content=unwrap(generation.get("text"), "")
         )
 
@@ -328,6 +353,8 @@ async def stream_generate_chat_completion(
 
         # We need to keep track of the text generated so we can resume the tool calls
         current_generation_text = ""
+        
+        is_reasoning_chunk = config.network.reasoning_parser
 
         # Consumer loop
         while True:
@@ -356,8 +383,14 @@ async def stream_generate_chat_completion(
             if isinstance(generation, Exception):
                 raise generation
 
+            if unwrap(generation.get("text"), "") == config.network.reasoning_end_token:
+                # Update reasoning chunk flag
+                is_reasoning_chunk = False
+                # And skip this token
+                continue
+            
             response = _create_stream_chunk(
-                request.state.id, generation, model_path.name
+                request.state.id, generation, model_path.name, is_reasoning_chunk=is_reasoning_chunk
             )
             yield response.model_dump_json()
 


### PR DESCRIPTION
The PR solves [issue294](https://github.com/theroyallab/tabbyAPI/issues/294)

The PR implemented reasoning parser and streaming reasoning parser, and was tested on DeepSeek-R1-Distill-Llama-70B with frontend like Page Assist and Cherry Studio. In my tests, it worked well.

I added configuration entry points to `config.yml` and placed it under network section.
