### PR TITLE
Fix Tool Call JSON Serialization Error

### DIFF
--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -198,6 +198,16 @@ async def _append_template_metadata(data: ChatCompletionRequest, template_vars: 
         # Append to stop strings to halt for a tool call generation
         data.stop.extend(template_metadata.tool_starts)
 
+def serialize_tool_calls(tool_calls):
+    """Convert ToolCall objects to serializable dictionaries."""
+    result = []
+    for tc in tool_calls:
+        result.append({
+            "id": tc.id,
+            "type": tc.type,
+            "function": {"name": tc.function.name, "arguments": tc.function.arguments}
+        })
+    return result
 
 async def format_messages_with_template(
     messages: List[ChatCompletionMessage],
@@ -224,8 +234,9 @@ async def format_messages_with_template(
             message.content = concatenated_content
 
         if message.tool_calls:
-            message.tool_calls_json = json.dumps(message.tool_calls, indent=2)
-
+            # Convert ToolCall objects to serializable dictionaries
+            serializable_tool_calls = serialize_tool_calls(message.tool_calls)
+            message.tool_calls_json = json.dumps(serializable_tool_calls, indent=2)
     special_tokens_dict = model.container.get_special_tokens(
         add_bos_token, ban_eos_token
     )


### PR DESCRIPTION
## Is your pull request related to a problem? Please describe.
This PR fixes the issue described in #301 where TabbyAPI fails with `TypeError: Object of type ToolCall is not JSON serializable` when processing responses from tool calls. This occurs during the second phase of the tool calling workflow when trying to render templates containing tool responses.

## Why should this feature be added?
This fix is essential because it enables complete tool calling workflows in TabbyAPI. Without it, users can initiate tool calls but the server crashes when trying to process tool responses, making the entire tool calling feature unusable for real-world applications.

## Examples
Before the fix: Tool calling fails after the first round of tool calls with:
```
TypeError: Object of type ToolCall is not JSON serializable
```

After the fix:
```python
# Client usage
tool_call_result = client.chat.completions.create(
    model="my-model",
    messages=[
        {"role": "user", "content": "What's the weather in Miami and calculate 15 * 23?"},
        {"role": "assistant", "tool_calls": [...]}  # Tool calls get generated successfully 
        {"role": "tool", "content": "..."} # Tool responses now work properly
    ],
    tools=[...]
)
```

The complete conversation now works:
1. User asks a question requiring tools
2. Model generates tool calls correctly
3. Client processes tool calls and returns results
4. Model receives tool results and generates a final response

## Additional context
The implementation is minimal and non-disruptive - it simply adds a helper function to serialize ToolCall objects properly before JSON serialization. This approach maintains all the necessary data while ensuring compatibility with Python's JSON serialization.

The core of the fix is a new helper function:
```python
def serialize_tool_calls(tool_calls):
    """Convert ToolCall objects to serializable dictionaries."""
    result = []
    for tc in tool_calls:
        result.append({
            "id": tc.id,
            "type": tc.type,
            "function": {"name": tc.function.name, "arguments": tc.function.arguments}
        })
    return result
```

This approach follows best practices for JSON serialization of custom objects while maintaining backward compatibility.