### PR TITLE
Qwen model tool call templates

### DIFF
--- a/templates/tool_calls/qwen2.5.jinja
+++ b/templates/tool_calls/qwen2.5.jinja
@@ -1,0 +1,89 @@
+{# Metadata #}
+{% set stop_strings = ["<|im_start|>", "<|im_end|>"] %}
+{% set message_roles = ['system', 'user', 'assistant', 'tool'] %}
+{% set tool_start = "<tool_call>" %}
+{% set tool_end = "</tool_call>" %}
+{% set example_tool_call = '{"name": "example_tool", "arguments": {"arg_name": "value", "number_arg": 42}}' %}
+
+{% set initial_system_prompt %}
+You are Qwen, created by Alibaba Cloud. You are a helpful assistant.
+
+# Tools
+
+You may call one or more functions to assist with the user query.
+
+You are provided with function signatures within <tools></tools> XML tags:
+<tools>
+{{ tools_json }}
+</tools>
+
+For each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:
+<tool_call>
+{"name": "function_name", "arguments": {"arg1": "value1", "arg2": "value2"}}
+</tool_call>
+{% endset %}
+
+{% set tool_reminder %}
+Available Tools:
+<tools>
+{{ tools_json }}
+</tools>
+
+Tool Call Format Example:
+{{ tool_start }}
+{{ example_tool_call }}
+{{ tool_end }}
+
+Remember to:
+1. Begin tool calls with {{ tool_start }} and end with {{ tool_end }}
+2. Use correct data types for arguments (strings in quotes, numbers without quotes)
+3. Format your JSON properly
+{% endset %}
+
+{# Template #}
+{% for message in messages %}
+    {% set role = message['role'] | lower %}
+    {% if role not in message_roles %}
+        {{ raise_exception('Invalid role ' + message['role'] + '. Only ' + message_roles | join(', ') + ' are supported.') }}
+    {% endif %}
+    {% set content = message['content'] if message['content'] is defined else '' | trim %}
+    
+    {% if loop.first %}
+        {{ bos_token }}<|im_start|>{{ role }}
+        {% if role == 'system' %}
+            {{ initial_system_prompt }}
+        {% endif %}
+        {{ content }}<|im_end|>
+    {% else %}
+        <|im_start|>{{ role }}
+        {% if role == 'assistant' %}
+            {% if content %}
+                {{ content }}
+            {% endif %}
+            {% if 'tool_calls_json' in message and message['tool_calls_json'] %}
+                {% for tool_call in message['tool_calls_json'] | fromjson %}
+                    {{ tool_start }}
+                    {"name": "{{ tool_call.function.name }}", "arguments": {{ tool_call.function.arguments }}}
+                    {{ tool_end }}
+                {% endfor %}
+            {% endif %}
+        {% elif role == 'tool' %}
+            <tool_response>
+            {{ content }}
+            </tool_response>
+        {% else %}
+            {{ content }}
+        {% endif %}
+        <|im_end|>
+    {% endif %}
+{% endfor %}
+
+{% if tool_precursor %}
+    <|im_start|>system
+    {{ tool_reminder }}
+    <|im_end|>
+    <|im_start|>assistant
+    {{ tool_precursor }}{{ tool_start }}
+{% else %}
+    <|im_start|>assistant
+{% endif %}

--- a/templates/tool_calls/qwq-32b.jinja
+++ b/templates/tool_calls/qwq-32b.jinja
@@ -1,0 +1,114 @@
+{# Metadata #}
+{%- set stop_strings = ["<|im_start|>", "<|im_end|>"] -%}
+{%- set message_roles = ['system', 'user', 'assistant', 'tool'] -%}
+{%- set tool_start = "<tool_call>" -%}
+{%- set tool_end = "</tool_call>" -%}
+{%- set example_tool_call = '{
+  "name": "example_tool",
+  "arguments": {
+    "arg_name": 3,
+    "string_arg": "example value",
+    "boolean_arg": true
+  }
+}' -%}
+
+{%- set initial_system_prompt %}
+You are Qwen, created by Alibaba Cloud. You are a helpful assistant.
+# Tools
+You may call one or more functions to assist with the user query.
+You are provided with function signatures within <tools></tools> XML tags:
+<tools>
+{{ tools_json }}
+</tools>
+For each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:
+<tool_call>
+{"name": "function_name", "arguments": {"arg1": "value1", "arg2": "value2"}}
+</tool_call>
+{% endset -%}
+
+{%- set tool_reminder %}
+Available Tools:
+<tools>
+{{ tools_json }}
+</tools>
+Tool Call Format Example:
+{{ tool_start }}
+{{ example_tool_call }}
+{{ tool_end }}
+Prefix & Suffix: Begin tool calls with {{ tool_start }} and end with {{ tool_end }}.
+Argument Types: Use correct data types for arguments (e.g., strings in quotes, numbers without).
+{% endset -%}
+
+{# Template #}
+{%- for message in messages -%}
+    {%- set role = message['role'] | lower -%}
+    {%- if role not in message_roles -%}
+        {{ raise_exception('Invalid role ' + message['role'] + '. Only ' + message_roles | join(', ') + ' are supported.') }}
+    {%- endif -%}
+    {%- set content = message['content'] if message['content'] is defined else '' | trim -%}
+    
+    {%- if loop.first and role == 'system' -%}
+        {{- '<|im_start|>system\n' -}}
+        {{- initial_system_prompt -}}
+        {{- '\n' -}}
+        {{- content -}}
+        {{- '<|im_end|>\n' -}}
+    {%- elif loop.first -%}
+        {{- '<|im_start|>system\n' -}}
+        {{- initial_system_prompt -}}
+        {{- '<|im_end|>\n' -}}
+        {{- '<|im_start|>' + role + '\n' -}}
+        {{- content -}}
+        {{- '<|im_end|>\n' -}}
+    {%- elif not loop.first -%}  
+        {%- if role == 'assistant' -%}
+            {{- '<|im_start|>assistant' -}}
+            {%- if content -%}
+                {%- set processed_content = (content.split('</think>')|last).lstrip('\n') if '</think>' in content else content -%}
+                {{- '\n' + processed_content -}}
+            {%- endif -%}
+            {%- if 'tool_calls_json' in message and message['tool_calls_json'] -%}
+                {{- '\n' + tool_start + '\n' -}}
+                {{- message['tool_calls_json'] -}}
+                {{- '\n' + tool_end -}}
+            {%- elif message.tool_calls is defined and message.tool_calls -%}
+                {%- for tool_call in message.tool_calls -%}
+                    {%- if tool_call.function is defined -%}
+                        {%- set func = tool_call.function -%}
+                    {%- else -%}
+                        {%- set func = tool_call -%}
+                    {%- endif -%}
+                    {{- '\n' + tool_start + '\n' -}}
+                    {"name": "{{ func.name }}", "arguments": {{ func.arguments | tojson }}}
+                    {{- '\n' + tool_end -}}
+                {%- endfor -%}
+            {%- endif -%}
+            {{- '<|im_end|>\n' -}}
+        {%- elif role == 'tool' -%}
+            {%- if (loop.index0 == 0) or (messages[loop.index0 - 1]['role'] != "tool") -%}
+                {{- '<|im_start|>user' -}}
+            {%- endif -%}
+            {{- '\n<tool_response>\n' -}}
+            {{- content -}}
+            {{- '\n</tool_response>' -}}
+            {%- if loop.last or (messages[loop.index0 + 1]['role'] != "tool") -%}
+                {{- '<|im_end|>\n' -}}
+            {%- endif -%}
+        {%- else -%}
+            {{- '<|im_start|>' + role + '\n' -}}
+            {{- content -}}
+            {{- '<|im_end|>\n' -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if tool_precursor -%}
+    {{- '<|im_start|>system\n' -}}
+    {{- tool_reminder -}}
+    {{- '<|im_end|>\n' -}}
+    {{- '<|im_start|>assistant\n' -}}
+    {{- tool_precursor -}}
+    {{- tool_start -}}
+{%- else -%}
+    {{- '<|im_start|>assistant\n' -}}
+{%- endif -%}


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
TabbyAPI currently lacks support for Qwen models, specifically Qwen 2.5 and QwQ-32B. Users who want to use these models with TabbyAPI need to create custom templates manually.

**Why should this feature be added?**
Adding native support for Qwen model templates will improve the user experience by:
1. Eliminating the need for users to create custom templates for these popular models
2. Ensuring proper formatting and handling of the specific requirements of Qwen models
3. Expanding TabbyAPI's compatibility with more AI models, making it more versatile

**Examples**
With these templates added:
- Users can simply select "qwen2.5.jinja" or "qwq-32b.jinja" when configuring TabbyAPI for use with Qwen models
- The templates handle all the necessary formatting including proper handling of:
  - Message roles (system, user, assistant, tool)
  - Tool calls with correct JSON formatting
  - Special tokens and formatting required by Qwen models

Without these templates, users would need to:
- Research the correct format for Qwen models
- Create their own templates with proper handling of all edge cases
- Troubleshoot any formatting issues themselves

**Additional context**
These templates follow the official formatting requirements for Qwen models and include proper handling of:
- System prompts
- Tool calling functionality
- Special tokens and message boundaries
- Proper JSON formatting for arguments