### PR TITLE
Bugfix: Chat completion requests fail with UnboundLocalError: finish_reason variable not initialized

### DIFF
--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -76,7 +76,7 @@ def _create_response(
 
         # Initialize finish_reason with a default value or from generation data
         finish_reason = generation.get("finish_reason", "stop")
-        
+
         # If a tool call is present, mark the finish reason as such
         if message.tool_calls:
             finish_reason = "tool_calls"

--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -74,7 +74,9 @@ def _create_response(
 
             logprob_response = ChatCompletionLogprobs(content=collected_token_probs)
 
-        # Finish reason will always be present in a completion
+        # Initialize finish_reason with a default value or from generation data
+        finish_reason = generation.get("finish_reason", "stop")
+        
         # If a tool call is present, mark the finish reason as such
         if message.tool_calls:
             finish_reason = "tool_calls"


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
This PR fixes issue #306 where chat completion requests fail with a 503 error due to an `UnboundLocalError`. The error occurs in the `_create_response` function when the variable `finish_reason` is accessed before being initialized, specifically when no tool calls are present in the response.

**Why should this feature be added?**
This isn't a new feature but a critical bug fix. The current implementation causes all chat completion requests to fail when the response doesn't include tool calls. This fix ensures that the `finish_reason` variable is always initialized before it's used, preventing the server from crashing.

**Examples**
Before the fix:
```
UnboundLocalError: cannot access local variable 'finish_reason' where it is not associated with a value
```
The server returns a 503 error, and users see an error message about the model possibly being unloaded.

After the fix:
Chat completion requests work as expected, with a properly initialized `finish_reason` value, allowing the server to respond with a valid 200 response rather than crashing with an error.

**Additional context**
The fix is minimal and straightforward - it initializes the `finish_reason` variable before the conditional block that previously was the only place it got assigned. This ensures the variable always has a value when it's used in the `ChatCompletionRespChoice` constructor, regardless of whether tool calls are present in the response.