### PR TITLE
Create general function to write the start options

### DIFF
--- a/start.py
+++ b/start.py
@@ -158,6 +158,22 @@ def migrate_gpu_lib():
         "The old file has been deleted."
     )
 
+def write_start_options_if_first_run(first_run, start_options):
+    # First run options
+    if first_run:
+        start_options["first_run_done"] = True
+
+        # Save start options
+        with open("start_options.json", "w") as start_file:
+            start_file.write(json.dumps(start_options))
+
+            print(
+                "Successfully wrote your start script options to "
+                "`start_options.json`. \n"
+                "If something goes wrong, editing or deleting the file "
+                "will reinstall TabbyAPI as a first-time user."
+            )
+
 
 if __name__ == "__main__":
     subprocess.run(["pip", "-V"])
@@ -236,21 +252,11 @@ if __name__ == "__main__":
         subprocess.run(install_command)
         print()
 
-        if first_run:
-            start_options["first_run_done"] = True
-
-            # Save start options on first run
-            with open("start_options.json", "w") as start_file:
-                start_file.write(json.dumps(start_options))
-
-                print(
-                    "Successfully wrote your start script options to "
-                    "`start_options.json`. \n"
-                    "If something goes wrong, editing or deleting the file "
-                    "will reinstall TabbyAPI as a first-time user."
-                )
-
         if args.update_deps:
+            # If the update_deps command is run on the first_run (like building in a docker container)
+            # Then write the start_options to avoid re-running
+            write_start_options_if_first_run(first_run, start_options)
+
             print(
                 f"Dependencies updated. Please run TabbyAPI with `start.{script_ext}`. "
                 "Exiting."
@@ -261,6 +267,9 @@ if __name__ == "__main__":
                 f"Dependencies installed. Update them with `update_deps.{script_ext}` "
                 "inside the `update_scripts` folder."
             )
+
+    # Write the start_options to a file on the first run to save them for subsequent runs
+    write_start_options_if_first_run(first_run, start_options)
 
     # Expand the parser if it's not fully created
     if not has_full_parser:


### PR DESCRIPTION
This PR further refactors the start options file writing. This ensures that the start options can be written consistently whether we are just updating dependencies, updating deps on first run, or just running for the first time