### PR TITLE
Exllamav3 cache quantization

### DIFF
--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -185,6 +185,7 @@ class ExllamaV2Container(BaseModelContainer):
         # MARK: User configuration
 
         # Get cache mode
+        # TODO: Separate validation for Exl2 and Exl3 q-cache options
         self.cache_mode = unwrap(kwargs.get("cache_mode"), "FP16")
 
         # Turn off GPU split if the user is using 1 GPU

--- a/backends/exllamav2/model.py
+++ b/backends/exllamav2/model.py
@@ -185,8 +185,16 @@ class ExllamaV2Container(BaseModelContainer):
         # MARK: User configuration
 
         # Get cache mode
-        # TODO: Separate validation for Exl2 and Exl3 q-cache options
         self.cache_mode = unwrap(kwargs.get("cache_mode"), "FP16")
+
+        # Catch exllamav3 cache_mode
+        if not self.cache_mode.startswith("Q"):
+            logger.warning(
+                f"Provided cache mode '{self.cache_mode}' is not a "
+                "valid choice for exllamav2, please check your settings. "
+                "Defaulting to FP16."
+            )
+            self.cache_mode = "FP16"
 
         # Turn off GPU split if the user is using 1 GPU
         gpu_count = torch.cuda.device_count()
@@ -392,6 +400,15 @@ class ExllamaV2Container(BaseModelContainer):
 
             # Set draft cache mode
             self.draft_cache_mode = unwrap(draft_args.get("draft_cache_mode"), "FP16")
+
+            # Catch exllamav3 draft_cache_mode
+            if not self.draft_cache_mode.startswith("Q"):
+                logger.warning(
+                    f"Provided draft cache mode '{self.draft_cache_mode}' is not a "
+                    "valid choice for exllamav2, please check your settings. "
+                    "Defaulting to FP16."
+                )
+                self.draft_cache_mode = "FP16"
 
             # Edit the draft config size
             if chunk_size:

--- a/backends/exllamav3/model.py
+++ b/backends/exllamav3/model.py
@@ -165,9 +165,7 @@ class ExllamaV3Container(BaseModelContainer):
             self.draft_model_dir = draft_model_path
             self.draft_config = Config.from_directory(str(draft_model_path.resolve()))
             self.draft_model = Model.from_config(self.draft_config)
-            logger.info(
-                f'Using draft model: {str(draft_model_path.resolve())}'
-            )
+            logger.info(f"Using draft model: {str(draft_model_path.resolve())}")
         else:
             self.draft_model = None
             self.craft_cache = None
@@ -262,7 +260,9 @@ class ExllamaV3Container(BaseModelContainer):
                 case "Q8":
                     self.draft_cache_mode = "8,8"
 
-            split_draft_cache_mode = re.search(r"^([2-8])\s*,\s*([2-8])$", self.draft_cache_mode)
+            split_draft_cache_mode = re.search(
+                r"^([2-8])\s*,\s*([2-8])$", self.draft_cache_mode
+            )
             if split_draft_cache_mode:
                 draft_k_bits = int(split_draft_cache_mode.group(1))
                 draft_v_bits = int(split_draft_cache_mode.group(2))
@@ -274,7 +274,9 @@ class ExllamaV3Container(BaseModelContainer):
                     v_bits=draft_v_bits,
                 )
             else:
-                self.draft_cache = Cache(self.draft_model, max_num_tokens = self.cache_size)
+                self.draft_cache = Cache(
+                    self.draft_model, max_num_tokens=self.cache_size
+                )
 
         # Max batch size
         self.max_batch_size = unwrap(kwargs.get("max_batch_size"), 256)

--- a/backends/exllamav3/model.py
+++ b/backends/exllamav3/model.py
@@ -233,7 +233,7 @@ class ExllamaV3Container(BaseModelContainer):
             case "Q8":
                 self.cache_mode = "8,8"
 
-        split_cache_mode = re.search(r"^([2-8]),([2-8])$", self.cache_mode)
+        split_cache_mode = re.search(r"^([2-8])\s*,\s*([2-8])$", self.cache_mode)
         if split_cache_mode:
             k_bits = int(split_cache_mode.group(1))
             v_bits = int(split_cache_mode.group(2))

--- a/common/config_models.py
+++ b/common/config_models.py
@@ -10,7 +10,7 @@ from typing import List, Literal, Optional, Union
 
 
 CACHE_SIZES = Literal["FP16", "Q8", "Q6", "Q4"]
-CACHE_TYPE = Union[CACHE_SIZES, constr(pattern=r"^[2-8],[2-8]$")]
+CACHE_TYPE = Union[CACHE_SIZES, constr(pattern=r"^[2-8]\s*,\s*[2-8]$")]
 
 
 class Metadata(BaseModel):

--- a/common/config_models.py
+++ b/common/config_models.py
@@ -229,7 +229,6 @@ class ModelConfig(BaseConfigModel):
             "or auto-calculate."
         ),
     )
-    # TODO: Separate validation for Exl2 and Exl3 q-cache options
     cache_mode: Optional[CACHE_TYPE] = Field(
         "FP16",
         description=(

--- a/common/config_models.py
+++ b/common/config_models.py
@@ -1,6 +1,7 @@
 from pydantic import (
     BaseModel,
     ConfigDict,
+    constr,
     Field,
     PrivateAttr,
     field_validator,
@@ -9,6 +10,7 @@ from typing import List, Literal, Optional, Union
 
 
 CACHE_SIZES = Literal["FP16", "Q8", "Q6", "Q4"]
+CACHE_TYPE = Union[CACHE_SIZES, constr(pattern=r"^[2-8],[2-8]$")]
 
 
 class Metadata(BaseModel):
@@ -227,11 +229,14 @@ class ModelConfig(BaseConfigModel):
             "or auto-calculate."
         ),
     )
-    cache_mode: Optional[CACHE_SIZES] = Field(
+    # TODO: Separate validation for Exl2 and Exl3 q-cache options
+    cache_mode: Optional[CACHE_TYPE] = Field(
         "FP16",
         description=(
             "Enable different cache modes for VRAM savings (default: FP16).\n"
-            f"Possible values: {str(CACHE_SIZES)[15:-1]}."
+            f"Possible values for exllamav2: {str(CACHE_SIZES)[15:-1]}.\n"
+            "For exllamav3, specify the pair k_bits,v_bits where k_bits and v_bits "
+            "are integers from 2-8 (i.e. 8,8)."
         ),
     )
     cache_size: Optional[int] = Field(

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -114,7 +114,8 @@ model:
   rope_alpha:
 
   # Enable different cache modes for VRAM savings (default: FP16).
-  # Possible values: 'FP16', 'Q8', 'Q6', 'Q4'.
+  # Possible values for exllamav2: 'FP16', 'Q8', 'Q6', 'Q4'.
+  # For exllamav3, specify the pair k_bits,v_bits where k_bits and v_bits are integers from 2-8 (i.e. 8,8).
   cache_mode: FP16
 
   # Size of the prompt cache to allocate (default: max_seq_len).
@@ -164,7 +165,8 @@ draft_model:
   draft_rope_alpha:
 
   # Cache mode for draft models to save VRAM (default: FP16).
-  # Possible values: 'FP16', 'Q8', 'Q6', 'Q4'.
+  # Possible values for exllamav2: 'FP16', 'Q8', 'Q6', 'Q4'.
+  # For exllamav3, specify the pair k_bits,v_bits where k_bits and v_bits are integers from 2-8 (i.e. 8,8).
   draft_cache_mode: FP16
 
   # An integer array of GBs of VRAM to split between GPUs (default: []).

--- a/endpoints/OAI/types/chat_completion.py
+++ b/endpoints/OAI/types/chat_completion.py
@@ -84,7 +84,7 @@ class ChatCompletionRequest(CommonCompletionRequest):
 
     # Chat completions requests do not have a BOS token preference. Backend
     # respects the tokenization config for the individual model.
-    add_bos_token: Optional[bool] = Field(default = None)
+    add_bos_token: Optional[bool] = Field(default=None)
 
     @field_validator("add_bos_token", mode="after")
     def force_bos_token(cls, v):


### PR DESCRIPTION
Add support for cache quantization to the exllamav3 backend.

TODO:
- [X] Initial support
- [X] Separate arg validation for exllamav2 and exllamav3 `cache_mode` - implemented in a limited manner to avoid breaking change