### PR TITLE
fix: Aligned Parameter Name in chat completions generate_tool_calls

### DIFF
--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -471,13 +471,13 @@ async def generate_tool_calls(
 
             if "text" in gen:
                 # non streaming, all generations will have the text they generated
-                pre_tool_prompt, mm_embeddings = await apply_chat_template(
+                pre_tool_prompt, embeddings = await apply_chat_template(
                     data, gen["text"]
                 )
             elif current_generations is not None:
                 # streaming, we wont have text in the generation,
                 # we'll have to use the current_generations
-                pre_tool_prompt, mm_embeddings = await apply_chat_template(
+                pre_tool_prompt, embeddings = await apply_chat_template(
                     data, current_generations
                 )
 
@@ -489,7 +489,7 @@ async def generate_tool_calls(
                         request_id,
                         pre_tool_prompt,
                         tool_data,
-                        embeddings=mm_embeddings,
+                        mm_embeddings=embeddings,
                     )
                 )
             )


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
A recent refactor removed the `**kwargs` catch-all from model.container.generate(), replacing it with an explicit parameter list and renaming the former embeddings argument to mm_embeddings. The invocation in generate_tool_calls was overlooked and still supplies embeddings=… 

```
# Inside generate_tool_calls
asyncio.create_task(
    model.container.generate(
        request_id,
        pre_tool_prompt,
        tool_data,
        embeddings=mm_embeddings,
    )
)
```

which would raise:

```
TypeError: generate() got an unexpected keyword argument 'embeddings'
```

**Why should this feature be added?**
This fixes this issue, tool calls should now be able to be generated again. I also aligned the variable name with the same variable in the `generate_chat_completion` function above

**Additional context**
<img width="1093" alt="Screenshot 2025-05-07 at 21 19 41" src="https://github.com/user-attachments/assets/7197f02a-fed3-4886-b73a-aea3441bcddb" />
* The changed file is `backends/exllamav2/model.py`
* This change is related to the broader “Model rewrite” in PR  #322 .
* The faulty call occurred within `generate_tool_calls` when the LLM triggered a tool call.
