### PR TITLE
API: accept enable_thinking template variable (to disable thinking with Qwen3)

### DIFF
--- a/endpoints/OAI/types/chat_completion.py
+++ b/endpoints/OAI/types/chat_completion.py
@@ -65,6 +65,7 @@ class ChatCompletionRequest(CommonCompletionRequest):
     messages: List[ChatCompletionMessage] = Field(default_factory=list)
     prompt_template: Optional[str] = None
     add_generation_prompt: Optional[bool] = True
+    enable_thinking: Optional[bool] = None
     template_vars: Optional[dict] = {}
     response_prefix: Optional[str] = None
     model: Optional[str] = None

--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -266,6 +266,7 @@ async def apply_chat_template(
                 "functions": data.functions,
                 "functions_json": json.dumps(data.functions, indent=2),
                 "tool_precursor": tool_precursor,
+                "enable_thinking": data.enable_thinking,
             }
         )
 


### PR DESCRIPTION
When a chat completion request defines the enable_thinking variable it will be applied to the chat template.

**Is your pull request related to a problem? Please describe.**
Adds support for the qwen3 enable_thinking template variable.

**Why should this feature be added?**
Allows to more cleanly disable thinking. As opposed to using /no_think, which still results in an empty <think> tag, this method injects the think tag in the response, which prevents generation of the reasoning block.

**Examples**
Tested on the exl3 branch with this branch merged on top.

**Additional context**
Preserves original thinking when the variable is not sent or the template doesn't check for the variable.
