### PR TITLE
docs: adding instructions to setup in WSL2 with AMD GPU

### DIFF
--- a/docs/01.-Getting-Started.md
+++ b/docs/01.-Getting-Started.md
@@ -53,6 +53,51 @@ To get started, make sure you have the following installed on your system:
     1. Run `start.bat/sh`. The script will check if you're in a conda environment and skip venv checks.
     2. Run `python main.py` to start the API. This won't automatically upgrade your dependencies.
 
+### For WSL2 with AMD GPU Users
+1. Install WSL
+```pwsh
+wsl --install
+```
+2. Install and start Ubuntu 24.04
+```pwsh
+wsl --install Ubuntu
+cd ~
+```
+
+> [!note]
+> Make sure you have enough disk space. The base install (i.e. no models) will use ~65GB.
+
+3. Update system
+```bash
+sudo apt update && sudo apt upgrade -y
+```
+
+3. Install AMD ROCm software detailed on https://rocm.docs.amd.com/projects/radeon/en/latest/docs/install/wsl/install-radeon.html
+
+> [!note]
+> Ensure you have the 5.15.y kernel, not the latest 6.6 which ROCm doesn't support yet. You can check with `uname -r`, `5.15.167.4-microsoft-standard-WSL2+` is used at the time of testing.
+
+4. Install Python Dependencies
+```bash
+sudo apt install -y python-is-python3 python3-venv
+```
+
+4. Edit `/etc/wsl.conf` to avoid Python conflicts in Windows with the folloing lines
+```ini
+[interop]
+appendWindowsPath = false
+```
+
+4. Follow steps 1-3 in the [For Advanced Users](#for-advanced-users) section
+5. Replace `libhsa-runtime64.so` in PyTorch with the one supplied by AMD (Credit: https://github.com/comfyanonymous/ComfyUI/issues/6434)
+```sh
+location="$(pip show torch | grep Location | awk -F ": " '{print $2}')/torch/lib"
+mv $location/libhsa-runtime64.so $location/libhsa-runtime64.so.bak
+ln -s /opt/rocm/lib/libhsa-runtime64.so $location/libhsa-runtime64.so
+```
+
+5. Start the API by following step 4 in the [For Advanced Users](#for-advanced-users) section
+
 ## Download a Model
 
 TabbyAPI includes a built-in Hugging Face downloader that works via both the API and terminal. You can use the following command to download a repository with a specific branch revision:


### PR DESCRIPTION
This PR add new documentation for setting up tabbyAPI in WSL2 with an AMD GPU.

Working environment:
- Host OS: Windows 11 Build 26100
- WSL version: 2.5.7.0
- Ubuntu version: 24.04
- Kernel version: 5.15.167.4-microsoft-standard-WSL2+ (self-compiled)
- tabbyAPI commit: b555eeb6e7bc752507519ee7cbc164dda89b8594
- GPU: AMD 7900XTX
- AMD driver version: 25.3.1

Know limitations:
- Torch HSA runtime must be replaced

I can provide the exported WSL2 machine if anyone need.