### PR TITLE
Exl3: some models aren't functional without add_bos?

### DIFF
--- a/backends/exllamav3/model.py
+++ b/backends/exllamav3/model.py
@@ -844,7 +844,7 @@ class ExllamaV3Container(BaseModelContainer):
         job = AsyncJob(
             self.generator,
             sampler=sampler,
-            input_ids=self.tokenizer.encode(prompt, add_bos=False),
+            input_ids=input_ids,
             max_new_tokens=max_tokens,
             stop_conditions=stop_conditions,
             banned_strings=params.banned_strings,


### PR DESCRIPTION
Gemma 3 works for me with `add_bos = True, encode_special_tokens = True` (as in [here](https://github.com/turboderp-org/exllamav3/blob/master/examples/chat.py#L103)), but right now it is explicitly `add_bos=False`, is this intended? That makes the generation broken with endless repetitions (same in the `chat.py` example, if I change it to `add_bos=False`).