### PR TITLE
Inject <think> to responses when forced thinking in chat template

### DIFF
--- a/endpoints/OAI/types/chat_completion.py
+++ b/endpoints/OAI/types/chat_completion.py
@@ -57,7 +57,7 @@ class ChatCompletionStreamChoice(BaseModel):
 class ChatCompletionRequest(CommonCompletionRequest):
     messages: List[ChatCompletionMessage]
     prompt_template: Optional[str] = None
-    add_generation_prompt: Optional[bool] = True
+    add_generation_prompt: Optional[bool] = None
     template_vars: Optional[dict] = Field(
         default={},
         validation_alias=AliasChoices("template_vars", "chat_template_kwargs"),


### PR DESCRIPTION
Adds logic to prepend '\<think\>' to the first streamed chunk and all final generations if the chat template ends with 'think'. Adjusts token and offset accounting to remain consistent when the tag is injected.

**Is your pull request related to a problem? Please describe.**
Close issue https://github.com/theroyallab/tabbyAPI/issues/361, now you can happily force thinking on all supported models.