### PR TITLE
Config: Remove developer arg cuda_malloc_backend

### DIFF
--- a/common/config_models.py
+++ b/common/config_models.py
@@ -419,9 +419,6 @@ class DeveloperConfig(BaseConfigModel):
     disable_request_streaming: Optional[bool] = Field(
         False, description=("Disable API request streaming (default: False).")
     )
-    cuda_malloc_backend: Optional[bool] = Field(
-        False, description=("Enable the torch CUDA malloc backend (default: False).")
-    )
     realtime_process_priority: Optional[bool] = Field(
         False,
         description=(

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -216,9 +216,6 @@ developer:
   # Disable API request streaming (default: False).
   disable_request_streaming: false
 
-  # Enable the torch CUDA malloc backend (default: False).
-  cuda_malloc_backend: false
-
   # Set process to use a higher priority.
   # For realtime process priority, run as administrator or sudo.
   # Otherwise, the priority will be set to high.


### PR DESCRIPTION
cudaMallocAsync is now enabled by default on supported configurations as of 113643c0df73a52685c7fc54768307c6e06a051b.