### PR TITLE
add logprobs support for exl3

### DIFF
--- a/backends/exllamav3/model.py
+++ b/backends/exllamav3/model.py
@@ -624,7 +624,6 @@ class ExllamaV3Container(BaseModelContainer):
 
         return dict(zip_longest(top_tokens, cleaned_values))
 
-
     async def generate(
         self,
         request_id: str,


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
exl3 backend code is missing logprobs support

**Why should this feature be added?**
logprobs are very useful both for roleplay plebs for easy rerolling from the middle of the message (as well as for generally getting some very convenient info about what the model could have said instead), as well as for programmers using using models for classification (asking to reply with a single token and looking at probabilities).

**Examples**
<img width="1248" height="427" alt="firefox_oGWYePztIR" src="https://github.com/user-attachments/assets/a5961f10-199e-4b3a-891d-58a4dff3b39b" />

**Additional context**
The code is mostly copied from exl2 implementation. Works on my windows machine in a fresh installation; exl3 library does support logprobs via the same `return_top_tokens` arg.