### PR TITLE
Replace outdated mentions of cu121 by cu128

### DIFF
--- a/colab/TabbyAPI_Colab_Example.ipynb
+++ b/colab/TabbyAPI_Colab_Example.ipynb
@@ -56,7 +56,7 @@
         "%cd tabbyAPI\n",
         "\n",
         "# Install cuda requirements\n",
-        "!pip install .[cu121] -q\n",
+        "!pip install .[cu128] -q\n",
         "!pip install huggingface-hub -q\n",
         "\n",
         "# Download cloudflared tunnel\n",

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,8 +26,8 @@ WORKDIR /app
 # Get requirements
 COPY pyproject.toml .
 
-# Install packages specified in pyproject.toml cu121, extras
-RUN pip install --no-cache-dir .[cu121,extras]
+# Install packages specified in pyproject.toml cu128, extras
+RUN pip install --no-cache-dir .[cu128,extras]
 
 RUN rm pyproject.toml
 

--- a/docs/01.-Getting-Started.md
+++ b/docs/01.-Getting-Started.md
@@ -3,7 +3,7 @@
 To get started, make sure you have the following installed on your system:
 
 - [Python 3.x](https://www.python.org/downloads/release/python-3117/) (preferably 3.11) with pip
-  
+
     - Do NOT install python from the Microsoft store! This will cause issues with pip.
     - Alternatively, you can use miniconda or uv if it's present on your system.
 
@@ -13,11 +13,11 @@ To get started, make sure you have the following installed on your system:
 
 > [!WARNING]
 > CUDA and ROCm aren't prerequisites because torch can install them for you. However, if this doesn't work (ex. DLL load failed), install the CUDA toolkit or ROCm on your system.
-> 
+>
 > - [CUDA 12.x](https://developer.nvidia.com/cuda-downloads)
->   
+>
 > - [ROCm 6.1](https://rocm.docs.amd.com/projects/install-on-linux/en/docs-6.1.0/how-to/prerequisites.html)
->   
+>
 
 > [!WARNING]
 > Sometimes there may be an error with Windows that VS build tools needs to be installed. This means that there's a package that isn't supported for your python version.
@@ -32,10 +32,10 @@ To get started, make sure you have the following installed on your system:
 2. Navigate to the project directory: `cd tabbyAPI`
 
 3. Run the appropriate start script (`start.bat` for Windows and `start.sh` for linux).
-  
+
     1. Follow the on-screen instructions and select the correct GPU library.
     2. Assuming that the prerequisites are installed and can be located, a virtual environment will be created for you and dependencies will be installed.
-  
+
 4. The API should start with no model loaded. Please read more to see how to download a model.
 
 ### For Advanced Users
@@ -47,7 +47,7 @@ To get started, make sure you have the following installed on your system:
         1. On Windows: `.\venv\Scripts\activate`
         2. On Linux: `source venv/bin/activate`
 3. Install the pyproject features based on your system:
-    1. Cuda 12.x: `pip install -U .[cu121]`
+    1. Cuda 12.x: `pip install -U .[cu128]`
     2. ROCm 5.6: `pip install -U .[amd]`
 4. Start the API by either
     1. Run `start.bat/sh`. The script will check if you're in a conda environment and skip venv checks.
@@ -95,7 +95,7 @@ There are a couple ways to update TabbyAPI:
 These scripts exit after running their respective tasks. To start TabbyAPI, run `start.bat` or `start.sh`.
 
 2. **Manual** - Install the pyproject features and update dependencies depending on your GPU:
-    1. `pip install -U .[cu121]` = CUDA 12.x
+    1. `pip install -U .[cu128]` = CUDA 12.x
     2. `pip install -U .[amd]` = ROCm 6.0
 
 If you don't want to update dependencies that come from wheels (torch, exllamav2, and flash attention 2), use `pip install .` or pass the `--nowheel` flag when invoking the start scripts.
@@ -113,12 +113,12 @@ NOTE:
 - TabbyAPI enforces the latest Exllamav2 version for compatibility purposes.
 - Any upgrades using a pyproject gpu lib feature will result in overwriting your installed wheel.
     - To fix this, change the feature in `pyproject.toml` locally, create an issue or PR, or install your version of exllamav2 after upgrades.
-  
+
 
 Here are ways to install exllamav2:
 
 1. From a [wheel/release](https://github.com/turboderp/exllamav2#method-2-install-from-release-with-prebuilt-extension) (Recommended)
-    1. Find the version that corresponds with your cuda and python version. For example, a wheel with `cu121` and `cp311` corresponds to CUDA 12.1 and python 3.11
+    1. Find the version that corresponds with your cuda and python version. For example, a wheel with `cu128` and `cp311` corresponds to CUDA 12.8 and python 3.11
 2. From [pip](https://github.com/turboderp/exllamav2#method-3-install-from-pypi): `pip install exllamav2`
     2. This is a JIT compiled extension, which means that the initial launch of tabbyAPI will take some time. The build may also not work due to improper environment configuration.
 3. From [source](https://github.com/turboderp/exllamav2#method-1-install-from-source)
@@ -137,7 +137,7 @@ These are short-form instructions for other methods that users can use to instal
 3. Activate the conda environment `conda activate tabbyAPI`
 4. Install optional dependencies if they aren't present
     1. CUDA via
-        1. CUDA 12 - `conda install -c "nvidia/label/cuda-12.4.1" cuda`
+        1. CUDA 12 - `conda install -c "nvidia/label/cuda-12.8.1" cuda`
     2. Git via `conda install -k git`
 5. Clone TabbyAPI via `git clone https://github.com/theroyallab/tabbyAPI`
 6. Continue installation steps from:

--- a/main.py
+++ b/main.py
@@ -150,8 +150,8 @@ def entrypoint(
             f"update_deps.{'bat' if platform.system() == 'Windows' else 'sh'})\n\n"
             "Or you can manually run a requirements update "
             "using the following command:\n\n"
-            "For CUDA 12.1:\n"
-            "pip install --upgrade .[cu121]\n\n"
+            "For CUDA 12.8:\n"
+            "pip install --upgrade .[cu128]\n\n"
             "For ROCm:\n"
             "pip install --upgrade .[amd]\n\n"
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ extras = [
 dev = [
     "ruff == 0.11.10"
 ]
-cu121 = [
+cu128 = [
     # Torch (Extra index URLs not support in pyproject.toml)
     "torch @ https://download.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp313-cp313-win_amd64.whl ; platform_system == 'Windows' and python_version == '3.13'",
     "torch @ https://download.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp312-cp312-win_amd64.whl ; platform_system == 'Windows' and python_version == '3.12'",

--- a/start.py
+++ b/start.py
@@ -41,12 +41,12 @@ def get_user_choice(question: str, options_dict: dict):
 def get_install_features(lib_name: str = None):
     """Fetches the appropriate requirements file depending on the GPU"""
     install_features = None
-    possible_features = ["cu121", "cu118", "amd"]
+    possible_features = ["cu128", "cu118", "amd"]
 
     if not lib_name:
         # Ask the user for the GPU lib
         gpu_lib_choices = {
-            "A": {"pretty": "NVIDIA Cuda 12.x", "internal": "cu121"},
+            "A": {"pretty": "NVIDIA Cuda 12.x", "internal": "cu128"},
             "B": {"pretty": "NVIDIA Cuda 11.8 (Unsupported)", "internal": "cu118"},
             "C": {"pretty": "AMD", "internal": "amd"},
         }
@@ -135,7 +135,7 @@ def add_start_args(parser: argparse.ArgumentParser):
     start_group.add_argument(
         "--gpu-lib",
         type=str,
-        help="Select GPU library. Options: cu121, cu118, amd",
+        help="Select GPU library. Options: cu128, cu118, amd",
     )
 
 


### PR DESCRIPTION
This replaces mentions of cu121 by cu128 and Cuda 12.1 by Cuda 12.8.

As Cuda 12.8+ is mandatory for Blackwell, finding cu121 had me thinking "oh it's not compatible with my hardware" until I actually read the dependencies being pulled and seeing that they were tagged `+cu128`.

On a side-note i see a reference to cu118 that seems obsolete.