### PR TITLE
feat: Add XML tool call processing system for GLM-4.5 and Qwen3-Coder models

### DIFF
--- a/common/templating.py
+++ b/common/templating.py
@@ -89,7 +89,9 @@ class PromptTemplate:
 
         if hasattr(template_module, "xml_processor_type"):
             if isinstance(template_module.xml_processor_type, str):
-                template_metadata.xml_processor_type = template_module.xml_processor_type
+                template_metadata.xml_processor_type = (
+                    template_module.xml_processor_type
+                )
 
         self.metadata = template_metadata
         return template_metadata

--- a/common/templating.py
+++ b/common/templating.py
@@ -30,6 +30,9 @@ class TemplateMetadata:
 
     stop_strings: List[str] = field(default_factory=list)
     tool_start: Optional[str] = None
+    tool_end: Optional[str] = None
+    tool_call_format: str = "json"  # "json" or "xml"
+    xml_processor_type: Optional[str] = None  # "glm45", "custom", etc.
 
 
 class PromptTemplate:
@@ -75,6 +78,18 @@ class PromptTemplate:
         if hasattr(template_module, "tool_start"):
             if isinstance(template_module.tool_start, str):
                 template_metadata.tool_start = template_module.tool_start
+
+        if hasattr(template_module, "tool_end"):
+            if isinstance(template_module.tool_end, str):
+                template_metadata.tool_end = template_module.tool_end
+
+        if hasattr(template_module, "tool_call_format"):
+            if isinstance(template_module.tool_call_format, str):
+                template_metadata.tool_call_format = template_module.tool_call_format
+
+        if hasattr(template_module, "xml_processor_type"):
+            if isinstance(template_module.xml_processor_type, str):
+                template_metadata.xml_processor_type = template_module.xml_processor_type
 
         self.metadata = template_metadata
         return template_metadata

--- a/docs/GLM-4.5-Tool-Calling-Implementation.md
+++ b/docs/GLM-4.5-Tool-Calling-Implementation.md
@@ -1,0 +1,249 @@
+# GLM-4.5 Tool Calling Implementation for TabbyAPI
+
+This document describes the XML-based tool calling support implemented for GLM-4.5 models in TabbyAPI.
+
+## Overview
+
+GLM-4.5 models generate tool calls in XML format, which differs from the OpenAI JSON format that TabbyAPI expects. This implementation provides a generic XML tool call processor that converts GLM-4.5 XML tool calls to OpenAI-compatible JSON format.
+
+## Architecture
+
+### Components
+
+1. **BaseXMLToolCallProcessor** (`endpoints/OAI/utils/xml_tool_processors.py`)
+   - Abstract base class for XML tool call processors
+   - Provides common functionality for parsing and converting tool calls
+   - Extensible design allows support for other XML-based models
+
+2. **GLM45ToolCallProcessor** (`endpoints/OAI/utils/xml_tool_processors.py`)
+   - Concrete implementation for GLM-4.5 specific XML format
+   - Handles the `<tool_call>` and `<arg_key>/<arg_value>` structure
+   - Converts XML to OpenAI JSON format
+
+3. **XMLToolCallProcessorFactory** (`endpoints/OAI/utils/xml_tool_processors.py`)
+   - Factory class for creating appropriate XML processors
+   - Supports extensibility by allowing registration of new processor types
+
+4. **Enhanced TemplateMetadata** (`common/templating.py`)
+   - Extended to support XML tool call configuration
+   - New fields: `tool_call_format`, `xml_processor_type`, `tool_end`
+
+5. **Enhanced ToolCallProcessor** (`endpoints/OAI/utils/tools.py`)
+   - Added `from_text()` method that routes to appropriate processor
+   - Added `from_xml()` method for XML-specific processing
+   - Maintains backward compatibility with JSON processing
+
+### GLM-4.5 XML Format
+
+The GLM-4.5 model generates tool calls in this format:
+
+```xml
+<tool_call>function_name
+<arg_key>parameter1</arg_key>
+<arg_value>value1</arg_value>
+<arg_key>parameter2</arg_key>
+<arg_value>value2</arg_value>
+</tool_call>
+```
+
+This gets converted to OpenAI JSON format:
+
+```json
+{
+  "id": "call_12345",
+  "type": "function",
+  "function": {
+    "name": "function_name",
+    "arguments": "{\"parameter1\": \"value1\", \"parameter2\": \"value2\"}"
+  }
+}
+```
+
+## Usage
+
+### Template Configuration
+
+The GLM-4.5 template (`templates/tool_calls/glm-4p5-chat-template-tabbyapi.jinja`) includes:
+
+```jinja
+{# Metadata #}
+{%- set stop_strings = ["<|user|>", "<|assistant|>", "<|observation|>", "<|system|>"] -%}
+{%- set tool_start = "<tool_call>" -%}
+{%- set tool_end = "</tool_call>" -%}
+{%- set tool_call_format = "xml" -%}
+{%- set xml_processor_type = "glm45" -%}
+```
+
+### Loading GLM-4.5 Models
+
+When loading a GLM-4.5 model, specify the tool-calling template:
+
+```yaml
+# config.yml
+model:
+  model_name: "path/to/glm-4.5-model"
+  prompt_template: "tool_calls/glm-4p5-chat-template-tabbyapi"
+```
+
+Or via API:
+
+```bash
+curl -X POST "http://localhost:5000/v1/model/load" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "path/to/glm-4.5-model",
+    "prompt_template": "tool_calls/glm-4p5-chat-template-tabbyapi"
+  }'
+```
+
+### Tool Call Request
+
+Standard OpenAI-compatible tool calling request:
+
+```json
+{
+  "model": "glm-4.5",
+  "messages": [
+    {
+      "role": "user",
+      "content": "What's the weather in Beijing?"
+    }
+  ],
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "get_weather",
+        "description": "Get weather information",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "city": {
+              "type": "string",
+              "description": "City name"
+            },
+            "date": {
+              "type": "string",
+              "description": "Date in YYYY-MM-DD format"
+            }
+          },
+          "required": ["city"]
+        }
+      }
+    }
+  ]
+}
+```
+
+## Integration Flow
+
+1. **Template Processing**: The template metadata indicates XML format tool calls
+2. **Model Generation**: GLM-4.5 generates XML tool calls when `<tool_call>` trigger is detected
+3. **XML Parsing**: `GLM45ToolCallProcessor` parses the XML structure
+4. **JSON Conversion**: XML is converted to OpenAI-compatible JSON format
+5. **Standard Pipeline**: Converted tool calls flow through normal TabbyAPI processing
+
+## Extensibility
+
+### Adding New XML Processors
+
+To support other XML-based models:
+
+1. Create a new processor class extending `BaseXMLToolCallProcessor`
+2. Implement the required methods for the specific XML format
+3. Register the processor with the factory:
+
+```python
+# Custom processor
+class CustomXMLProcessor(BaseXMLToolCallProcessor):
+    def has_tool_call(self, text: str) -> bool:
+        return "<custom_tool>" in text
+    
+    def parse_xml_to_json(self, text: str, tools: List[Tool]) -> List[ToolCall]:
+        # Custom parsing logic
+        pass
+
+# Register processor
+XMLToolCallProcessorFactory.register_processor("custom", CustomXMLProcessor)
+```
+
+### Template Configuration
+
+Create a template with appropriate metadata:
+
+```jinja
+{%- set tool_call_format = "xml" -%}
+{%- set xml_processor_type = "custom" -%}
+{%- set tool_start = "<custom_tool>" -%}
+{%- set tool_end = "</custom_tool>" -%}
+```
+
+## Testing
+
+Unit tests are provided in `tests/test_xml_tool_calls.py` covering:
+
+- XML parsing functionality
+- Multiple tool call handling  
+- JSON conversion accuracy
+- Error handling for malformed XML
+- Factory pattern functionality
+- Argument type processing
+
+Run tests with:
+
+```bash
+python -m pytest tests/test_xml_tool_calls.py -v
+```
+
+## Error Handling
+
+The implementation includes robust error handling:
+
+- **Malformed XML**: Returns empty tool call list, logs error
+- **Unknown Functions**: Still processes but without type validation
+- **Parsing Failures**: Falls back gracefully, maintains system stability
+- **Missing Dependencies**: Graceful degradation to JSON processing
+
+## Performance Considerations
+
+- **Regex-based Parsing**: Efficient for typical tool call volumes
+- **Lazy Evaluation**: Processors created only when needed
+- **Memory Efficient**: Processes tool calls incrementally
+- **Caching**: Template metadata cached after first extraction
+
+## Compatibility
+
+- **Backward Compatible**: Existing JSON tool calling continues to work
+- **OpenAI Standard**: Output format matches OpenAI API specification
+- **Streaming Support**: Works with both streaming and non-streaming responses
+- **Multi-tool**: Supports multiple tool calls in single response
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Tool calls not detected**
+   - Verify template has `tool_call_format = "xml"`
+   - Check `tool_start` matches model output
+   - Ensure `xml_processor_type` is correct
+
+2. **Parsing errors**
+   - Validate XML format matches expected structure
+   - Check for missing closing tags
+   - Verify argument key/value pairing
+
+3. **JSON conversion failures**
+   - Check argument types in tool definitions
+   - Validate JSON-formatted argument values
+   - Review error logs for specific parsing issues
+
+### Debug Mode
+
+Enable detailed logging for troubleshooting:
+
+```python
+import logging
+logging.getLogger("endpoints.OAI.utils.xml_tool_processors").setLevel(logging.DEBUG)
+```
+
+This implementation provides a robust, extensible foundation for XML-based tool calling in TabbyAPI while maintaining full compatibility with existing JSON-based tool calling functionality.

--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -34,7 +34,10 @@ from endpoints.OAI.utils.tools import ToolCallProcessor, TOOL_CALL_SCHEMA
 
 
 def _create_response(
-    request_id: str, generations: List[dict], model_name: Optional[str], tools: Optional[List[ToolSpec]] = None
+    request_id: str,
+    generations: List[dict],
+    model_name: Optional[str],
+    tools: Optional[List[ToolSpec]] = None,
 ):
     """Create a chat completion response from the provided text."""
 

--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -152,12 +152,12 @@ def _create_stream_chunk(
                     tool_calls,
                     [],  # We don't have tools context in streaming
                     tool_call_format="xml",
-                    xml_processor_type=template_metadata.xml_processor_type
+                    xml_processor_type=template_metadata.xml_processor_type,
                 )
             else:
                 # Default to JSON processor
                 processed_tool_calls = ToolCallProcessor.from_json(tool_calls)
-            
+
             message = ChatCompletionMessage(tool_calls=processed_tool_calls)
             choice.delta = message
             choice.finish_reason = "tool_calls"
@@ -457,7 +457,9 @@ async def generate_chat_completion(
                 prompt, embeddings, data, generations, request
             )
 
-        response = _create_response(request.state.id, generations, model_path.name, data.tools)
+        response = _create_response(
+            request.state.id, generations, model_path.name, data.tools
+        )
 
         logger.info(f"Finished chat completion request {request.state.id}")
 

--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -27,13 +27,14 @@ from endpoints.OAI.types.chat_completion import (
     ChatCompletionResponse,
     ChatCompletionStreamChoice,
 )
+from endpoints.OAI.types.tools import ToolSpec
 from endpoints.OAI.types.common import UsageStats
 from endpoints.OAI.utils.completion import _parse_gen_request_id, _stream_collector
 from endpoints.OAI.utils.tools import ToolCallProcessor, TOOL_CALL_SCHEMA
 
 
 def _create_response(
-    request_id: str, generations: List[dict], model_name: Optional[str]
+    request_id: str, generations: List[dict], model_name: Optional[str], tools: Optional[List[ToolSpec]] = None
 ):
     """Create a chat completion response from the provided text."""
 

--- a/endpoints/OAI/utils/tools.py
+++ b/endpoints/OAI/utils/tools.py
@@ -44,9 +44,7 @@ class ToolCallProcessor:
 
     @staticmethod
     def from_xml(
-        tool_calls_text: str,
-        tools: List[Tool],
-        xml_processor_type: str = "glm45"
+        tool_calls_text: str, tools: List[Tool], xml_processor_type: str = "glm45"
     ) -> List[ToolCall]:
         """Process XML tool calls and convert to ToolCall objects"""
         try:
@@ -61,25 +59,30 @@ class ToolCallProcessor:
         tool_calls_text: str,
         tools: List[Tool],
         tool_call_format: str = "json",
-        xml_processor_type: Optional[str] = None
+        xml_processor_type: Optional[str] = None,
     ) -> List[ToolCall]:
         """
         Process tool calls from text, detecting format and routing appropriately.
-        
+
         Args:
             tool_calls_text: Raw text containing tool calls
             tools: Available tools for validation
             tool_call_format: Format type ("json" or "xml")
             xml_processor_type: Type of XML processor to use if format is XML
-            
+
         Returns:
             List of parsed ToolCall objects
         """
         if tool_call_format.lower() == "xml":
             if not xml_processor_type:
-                logger.warning("XML format specified but no xml_processor_type provided, using glm45")
+                logger.warning(
+                    "XML format specified but no xml_processor_type provided, "
+                    "using glm45"
+                )
                 xml_processor_type = "glm45"
-            return ToolCallProcessor.from_xml(tool_calls_text, tools, xml_processor_type)
+            return ToolCallProcessor.from_xml(
+                tool_calls_text, tools, xml_processor_type
+            )
         else:
             return ToolCallProcessor.from_json(tool_calls_text)
 

--- a/endpoints/OAI/utils/tools.py
+++ b/endpoints/OAI/utils/tools.py
@@ -1,8 +1,9 @@
 import json
 from loguru import logger
-from typing import List
+from typing import List, Optional
 
-from endpoints.OAI.types.tools import ToolCall
+from endpoints.OAI.types.tools import ToolCall, Tool
+from endpoints.OAI.utils.xml_tool_processors import XMLToolCallProcessorFactory
 
 
 TOOL_CALL_SCHEMA = {
@@ -40,6 +41,47 @@ class ToolCallProcessor:
             )
 
         return [ToolCall(**tool_call) for tool_call in tool_calls]
+
+    @staticmethod
+    def from_xml(
+        tool_calls_text: str,
+        tools: List[Tool],
+        xml_processor_type: str = "glm45"
+    ) -> List[ToolCall]:
+        """Process XML tool calls and convert to ToolCall objects"""
+        try:
+            processor = XMLToolCallProcessorFactory.create_processor(xml_processor_type)
+            return processor.parse_xml_to_json(tool_calls_text, tools)
+        except Exception as e:
+            logger.error(f"Error processing XML tool calls: {e}")
+            return []
+
+    @staticmethod
+    def from_text(
+        tool_calls_text: str,
+        tools: List[Tool],
+        tool_call_format: str = "json",
+        xml_processor_type: Optional[str] = None
+    ) -> List[ToolCall]:
+        """
+        Process tool calls from text, detecting format and routing appropriately.
+        
+        Args:
+            tool_calls_text: Raw text containing tool calls
+            tools: Available tools for validation
+            tool_call_format: Format type ("json" or "xml")
+            xml_processor_type: Type of XML processor to use if format is XML
+            
+        Returns:
+            List of parsed ToolCall objects
+        """
+        if tool_call_format.lower() == "xml":
+            if not xml_processor_type:
+                logger.warning("XML format specified but no xml_processor_type provided, using glm45")
+                xml_processor_type = "glm45"
+            return ToolCallProcessor.from_xml(tool_calls_text, tools, xml_processor_type)
+        else:
+            return ToolCallProcessor.from_json(tool_calls_text)
 
     @staticmethod
     def dump(tool_calls: List[ToolCall]) -> List[dict]:

--- a/endpoints/OAI/utils/xml_tool_processors.py
+++ b/endpoints/OAI/utils/xml_tool_processors.py
@@ -1,0 +1,163 @@
+"""XML tool call processors for converting XML-based tool calls to OpenAI JSON format."""
+
+import ast
+import json
+import re
+import logging
+from abc import ABC, abstractmethod
+from typing import List, Dict, Any, Optional, Union
+
+from endpoints.OAI.types.tools import ToolCall, Tool, ToolSpec
+
+logger = logging.getLogger(__name__)
+
+
+class BaseXMLToolCallProcessor(ABC):
+    """Base class for XML-based tool call processors."""
+    
+    def __init__(self):
+        self.tool_start_pattern: str = ""
+        self.tool_end_pattern: str = ""
+        
+    @abstractmethod
+    def has_tool_call(self, text: str) -> bool:
+        """Check if the text contains XML format tool calls."""
+        pass
+    
+    @abstractmethod
+    def parse_xml_to_json(self, text: str, tools: List[ToolSpec]) -> List[ToolCall]:
+        """Parse XML tool calls from text and convert to OpenAI JSON format."""
+        pass
+    
+    def _parse_arguments(self, json_value: str) -> tuple[Any, bool]:
+        """Parse argument value, trying JSON first, then literal_eval."""
+        try:
+            try:
+                parsed_value = json.loads(json_value)
+            except:
+                parsed_value = ast.literal_eval(json_value)
+            return parsed_value, True
+        except:
+            return json_value, False
+    
+    def _get_argument_type(self, func_name: str, arg_key: str, tools: List[ToolSpec]) -> Optional[str]:
+        """Get the expected type of an argument based on tool definition."""
+        name_to_tool = {tool.function.name: tool for tool in tools}
+        if func_name not in name_to_tool:
+            return None
+        tool = name_to_tool[func_name]
+        if arg_key not in tool.function.parameters["properties"]:
+            return None
+        return tool.function.parameters["properties"][arg_key].get("type", None)
+    
+    def _create_tool_call(self, name: str, arguments: Dict[str, Any], call_id: Optional[str] = None) -> ToolCall:
+        """Create a ToolCall object from parsed data."""
+        return ToolCall(
+            id=call_id or f"call_{hash(f'{name}_{json.dumps(arguments, sort_keys=True)}')}",
+            type="function",
+            function=Tool(
+                name=name,
+                arguments=json.dumps(arguments)
+            )
+        )
+
+
+class GLM45ToolCallProcessor(BaseXMLToolCallProcessor):
+    """
+    Tool call processor for GLM-4.5 models.
+    
+    Handles XML format like:
+    <tool_call>function_name
+    <arg_key>parameter1</arg_key>
+    <arg_value>value1</arg_value>
+    <arg_key>parameter2</arg_key>
+    <arg_value>value2</arg_value>
+    </tool_call>
+    """
+    
+    def __init__(self):
+        super().__init__()
+        self.tool_start_pattern = "<tool_call>"
+        self.tool_end_pattern = "</tool_call>"
+        self.func_call_regex = r"<tool_call>.*?</tool_call>"
+        self.func_detail_regex = r"<tool_call>([^\n]*)\n(.*)</tool_call>"
+        self.func_arg_regex = r"<arg_key>(.*?)</arg_key>\s*<arg_value>(.*?)</arg_value>"
+    
+    def has_tool_call(self, text: str) -> bool:
+        """Check if the text contains GLM-4.5 format tool calls."""
+        return self.tool_start_pattern in text
+    
+    def parse_xml_to_json(self, text: str, tools: List[ToolSpec]) -> List[ToolCall]:
+        """Parse GLM-4.5 XML tool calls and convert to OpenAI JSON format."""
+        if not self.has_tool_call(text):
+            return []
+        
+        # Find all tool call matches
+        match_results = re.findall(self.func_call_regex, text, re.DOTALL)
+        tool_calls = []
+        
+        try:
+            for match_result in match_results:
+                # Extract function name and arguments section
+                func_detail = re.search(self.func_detail_regex, match_result, re.DOTALL)
+                if not func_detail:
+                    logger.warning(f"Could not parse tool call: {match_result}")
+                    continue
+                
+                func_name = func_detail.group(1).strip()
+                func_args_section = func_detail.group(2).strip()
+                
+                # Extract argument key-value pairs
+                arg_pairs = re.findall(self.func_arg_regex, func_args_section, re.DOTALL)
+                arguments = {}
+                
+                for arg_key, arg_value in arg_pairs:
+                    arg_key = arg_key.strip()
+                    arg_value = arg_value.strip()
+                    
+                    # Get expected argument type from tool definition
+                    arg_type = self._get_argument_type(func_name, arg_key, tools)
+                    
+                    # Parse non-string arguments
+                    if arg_type != "string":
+                        arg_value, _ = self._parse_arguments(arg_value)
+                    
+                    arguments[arg_key] = arg_value
+                
+                # Create ToolCall object
+                tool_call = self._create_tool_call(func_name, arguments)
+                tool_calls.append(tool_call)
+            
+            return tool_calls
+            
+        except Exception as e:
+            logger.error(f"Error parsing GLM-4.5 XML tool calls: {e}")
+            return []
+
+
+class XMLToolCallProcessorFactory:
+    """Factory for creating appropriate XML tool call processors."""
+    
+    _processors = {
+        "glm45": GLM45ToolCallProcessor,
+        "glm-4.5": GLM45ToolCallProcessor,
+        "glm4": GLM45ToolCallProcessor,
+    }
+    
+    @classmethod
+    def create_processor(cls, processor_type: str) -> BaseXMLToolCallProcessor:
+        """Create an XML tool call processor of the specified type."""
+        processor_class = cls._processors.get(processor_type.lower())
+        if not processor_class:
+            raise ValueError(f"Unknown XML tool call processor type: {processor_type}")
+        return processor_class()
+    
+    @classmethod
+    def register_processor(cls, name: str, processor_class: type):
+        """Register a new XML tool call processor type."""
+        cls._processors[name.lower()] = processor_class
+    
+    @classmethod
+    def get_available_processors(cls) -> List[str]:
+        """Get list of available processor types."""
+        return list(cls._processors.keys())

--- a/endpoints/OAI/utils/xml_tool_processors.py
+++ b/endpoints/OAI/utils/xml_tool_processors.py
@@ -5,7 +5,7 @@ import json
 import re
 import logging
 from abc import ABC, abstractmethod
-from typing import List, Dict, Any, Optional, Union
+from typing import List, Dict, Any, Optional, Tuple
 
 from endpoints.OAI.types.tools import ToolCall, Tool, ToolSpec
 
@@ -29,15 +29,15 @@ class BaseXMLToolCallProcessor(ABC):
         """Parse XML tool calls from text and convert to OpenAI JSON format."""
         pass
     
-    def _parse_arguments(self, json_value: str) -> tuple[Any, bool]:
+    def _parse_arguments(self, json_value: str) -> Tuple[Any, bool]:
         """Parse argument value, trying JSON first, then literal_eval."""
         try:
             try:
                 parsed_value = json.loads(json_value)
-            except:
+            except (json.JSONDecodeError, ValueError):
                 parsed_value = ast.literal_eval(json_value)
             return parsed_value, True
-        except:
+        except (json.JSONDecodeError, ValueError, SyntaxError):
             return json_value, False
     
     def _get_argument_type(self, func_name: str, arg_key: str, tools: List[ToolSpec]) -> Optional[str]:

--- a/endpoints/OAI/utils/xml_tool_processors.py
+++ b/endpoints/OAI/utils/xml_tool_processors.py
@@ -1,4 +1,4 @@
-"""XML tool call processors for converting XML-based tool calls to OpenAI JSON format."""
+"""XML tool call processors for converting XML-based tool calls to OpenAI format."""
 
 import ast
 import json
@@ -14,21 +14,21 @@ logger = logging.getLogger(__name__)
 
 class BaseXMLToolCallProcessor(ABC):
     """Base class for XML-based tool call processors."""
-    
+
     def __init__(self):
         self.tool_start_pattern: str = ""
         self.tool_end_pattern: str = ""
-        
+
     @abstractmethod
     def has_tool_call(self, text: str) -> bool:
         """Check if the text contains XML format tool calls."""
         pass
-    
+
     @abstractmethod
     def parse_xml_to_json(self, text: str, tools: List[ToolSpec]) -> List[ToolCall]:
         """Parse XML tool calls from text and convert to OpenAI JSON format."""
         pass
-    
+
     def _parse_arguments(self, json_value: str) -> Tuple[Any, bool]:
         """Parse argument value, trying JSON first, then literal_eval."""
         try:
@@ -39,8 +39,10 @@ class BaseXMLToolCallProcessor(ABC):
             return parsed_value, True
         except (json.JSONDecodeError, ValueError, SyntaxError):
             return json_value, False
-    
-    def _get_argument_type(self, func_name: str, arg_key: str, tools: List[ToolSpec]) -> Optional[str]:
+
+    def _get_argument_type(
+        self, func_name: str, arg_key: str, tools: List[ToolSpec]
+    ) -> Optional[str]:
         """Get the expected type of an argument based on tool definition."""
         name_to_tool = {tool.function.name: tool for tool in tools}
         if func_name not in name_to_tool:
@@ -49,23 +51,23 @@ class BaseXMLToolCallProcessor(ABC):
         if arg_key not in tool.function.parameters["properties"]:
             return None
         return tool.function.parameters["properties"][arg_key].get("type", None)
-    
-    def _create_tool_call(self, name: str, arguments: Dict[str, Any], call_id: Optional[str] = None) -> ToolCall:
+
+    def _create_tool_call(
+        self, name: str, arguments: Dict[str, Any], call_id: Optional[str] = None
+    ) -> ToolCall:
         """Create a ToolCall object from parsed data."""
         return ToolCall(
-            id=call_id or f"call_{hash(f'{name}_{json.dumps(arguments, sort_keys=True)}')}",
+            id=call_id
+            or f"call_{hash(f'{name}_{json.dumps(arguments, sort_keys=True)}')}",
             type="function",
-            function=Tool(
-                name=name,
-                arguments=json.dumps(arguments)
-            )
+            function=Tool(name=name, arguments=json.dumps(arguments)),
         )
 
 
 class GLM45ToolCallProcessor(BaseXMLToolCallProcessor):
     """
     Tool call processor for GLM-4.5 models.
-    
+
     Handles XML format like:
     <tool_call>function_name
     <arg_key>parameter1</arg_key>
@@ -74,7 +76,7 @@ class GLM45ToolCallProcessor(BaseXMLToolCallProcessor):
     <arg_value>value2</arg_value>
     </tool_call>
     """
-    
+
     def __init__(self):
         super().__init__()
         self.tool_start_pattern = "<tool_call>"
@@ -82,20 +84,20 @@ class GLM45ToolCallProcessor(BaseXMLToolCallProcessor):
         self.func_call_regex = r"<tool_call>.*?</tool_call>"
         self.func_detail_regex = r"<tool_call>([^\n]*)\n(.*)</tool_call>"
         self.func_arg_regex = r"<arg_key>(.*?)</arg_key>\s*<arg_value>(.*?)</arg_value>"
-    
+
     def has_tool_call(self, text: str) -> bool:
         """Check if the text contains GLM-4.5 format tool calls."""
         return self.tool_start_pattern in text
-    
+
     def parse_xml_to_json(self, text: str, tools: List[ToolSpec]) -> List[ToolCall]:
         """Parse GLM-4.5 XML tool calls and convert to OpenAI JSON format."""
         if not self.has_tool_call(text):
             return []
-        
+
         # Find all tool call matches
         match_results = re.findall(self.func_call_regex, text, re.DOTALL)
         tool_calls = []
-        
+
         try:
             for match_result in match_results:
                 # Extract function name and arguments section
@@ -103,33 +105,35 @@ class GLM45ToolCallProcessor(BaseXMLToolCallProcessor):
                 if not func_detail:
                     logger.warning(f"Could not parse tool call: {match_result}")
                     continue
-                
+
                 func_name = func_detail.group(1).strip()
                 func_args_section = func_detail.group(2).strip()
-                
+
                 # Extract argument key-value pairs
-                arg_pairs = re.findall(self.func_arg_regex, func_args_section, re.DOTALL)
+                arg_pairs = re.findall(
+                    self.func_arg_regex, func_args_section, re.DOTALL
+                )
                 arguments = {}
-                
+
                 for arg_key, arg_value in arg_pairs:
                     arg_key = arg_key.strip()
                     arg_value = arg_value.strip()
-                    
+
                     # Get expected argument type from tool definition
                     arg_type = self._get_argument_type(func_name, arg_key, tools)
-                    
+
                     # Parse non-string arguments
                     if arg_type != "string":
                         arg_value, _ = self._parse_arguments(arg_value)
-                    
+
                     arguments[arg_key] = arg_value
-                
+
                 # Create ToolCall object
                 tool_call = self._create_tool_call(func_name, arguments)
                 tool_calls.append(tool_call)
-            
+
             return tool_calls
-            
+
         except Exception as e:
             logger.error(f"Error parsing GLM-4.5 XML tool calls: {e}")
             return []
@@ -137,13 +141,13 @@ class GLM45ToolCallProcessor(BaseXMLToolCallProcessor):
 
 class XMLToolCallProcessorFactory:
     """Factory for creating appropriate XML tool call processors."""
-    
+
     _processors = {
         "glm45": GLM45ToolCallProcessor,
         "glm-4.5": GLM45ToolCallProcessor,
         "glm4": GLM45ToolCallProcessor,
     }
-    
+
     @classmethod
     def create_processor(cls, processor_type: str) -> BaseXMLToolCallProcessor:
         """Create an XML tool call processor of the specified type."""
@@ -151,12 +155,12 @@ class XMLToolCallProcessorFactory:
         if not processor_class:
             raise ValueError(f"Unknown XML tool call processor type: {processor_type}")
         return processor_class()
-    
+
     @classmethod
     def register_processor(cls, name: str, processor_class: type):
         """Register a new XML tool call processor type."""
         cls._processors[name.lower()] = processor_class
-    
+
     @classmethod
     def get_available_processors(cls) -> List[str]:
         """Get list of available processor types."""

--- a/tests/test_xml_tool_calls.py
+++ b/tests/test_xml_tool_calls.py
@@ -1,0 +1,280 @@
+"""Unit tests for XML tool call processing functionality."""
+
+import pytest
+import json
+from endpoints.OAI.utils.xml_tool_processors import (
+    GLM45ToolCallProcessor,
+    XMLToolCallProcessorFactory,
+    BaseXMLToolCallProcessor
+)
+from endpoints.OAI.types.tools import ToolCall, ToolSpec, Function
+
+
+class TestGLM45ToolCallProcessor:
+    """Test GLM-4.5 XML tool call processor."""
+    
+    def setup_method(self):
+        """Set up test fixtures."""
+        self.processor = GLM45ToolCallProcessor()
+        self.sample_tools = [
+            ToolSpec(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information for a city",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string", "description": "City name"},
+                            "date": {"type": "string", "description": "Date in YYYY-MM-DD format"},
+                            "units": {"type": "string", "description": "Temperature units"}
+                        }
+                    }
+                )
+            ),
+            ToolSpec(
+                type="function",
+                function=Function(
+                    name="calculate_sum",
+                    description="Calculate the sum of numbers",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "numbers": {"type": "array", "description": "List of numbers"},
+                            "precision": {"type": "integer", "description": "Decimal precision"}
+                        }
+                    }
+                )
+            )
+        ]
+    
+    def test_has_tool_call_positive(self):
+        """Test detection of XML tool calls."""
+        text_with_tool = """Some text before
+<tool_call>get_weather
+<arg_key>city</arg_key>
+<arg_value>Beijing</arg_value>
+</tool_call>
+Some text after"""
+        
+        assert self.processor.has_tool_call(text_with_tool) is True
+    
+    def test_has_tool_call_negative(self):
+        """Test when no tool calls are present."""
+        text_without_tool = "This is just regular text with no tool calls."
+        
+        assert self.processor.has_tool_call(text_without_tool) is False
+    
+    def test_parse_single_tool_call(self):
+        """Test parsing a single XML tool call."""
+        xml_text = """<tool_call>get_weather
+<arg_key>city</arg_key>
+<arg_value>Beijing</arg_value>
+<arg_key>date</arg_key>
+<arg_value>2024-06-27</arg_value>
+</tool_call>"""
+        
+        result = self.processor.parse_xml_to_json(xml_text, self.sample_tools)
+        
+        assert len(result) == 1
+        assert isinstance(result[0], ToolCall)
+        assert result[0].function.name == "get_weather"
+        
+        arguments = json.loads(result[0].function.arguments)
+        assert arguments["city"] == "Beijing"
+        assert arguments["date"] == "2024-06-27"
+    
+    def test_parse_multiple_tool_calls(self):
+        """Test parsing multiple XML tool calls."""
+        xml_text = """<tool_call>get_weather
+<arg_key>city</arg_key>
+<arg_value>Beijing</arg_value>
+<arg_key>date</arg_key>
+<arg_value>2024-06-27</arg_value>
+</tool_call>
+
+<tool_call>calculate_sum
+<arg_key>numbers</arg_key>
+<arg_value>[1, 2, 3, 4, 5]</arg_value>
+<arg_key>precision</arg_key>
+<arg_value>2</arg_value>
+</tool_call>"""
+        
+        result = self.processor.parse_xml_to_json(xml_text, self.sample_tools)
+        
+        assert len(result) == 2
+        
+        # First tool call
+        assert result[0].function.name == "get_weather"
+        args1 = json.loads(result[0].function.arguments)
+        assert args1["city"] == "Beijing"
+        assert args1["date"] == "2024-06-27"
+        
+        # Second tool call
+        assert result[1].function.name == "calculate_sum"
+        args2 = json.loads(result[1].function.arguments)
+        assert args2["numbers"] == [1, 2, 3, 4, 5]
+        assert args2["precision"] == 2
+    
+    def test_parse_with_json_values(self):
+        """Test parsing XML tool calls with JSON-formatted argument values."""
+        xml_text = """<tool_call>calculate_sum
+<arg_key>numbers</arg_key>
+<arg_value>[10, 20, 30]</arg_value>
+<arg_key>precision</arg_key>
+<arg_value>3</arg_value>
+</tool_call>"""
+        
+        result = self.processor.parse_xml_to_json(xml_text, self.sample_tools)
+        
+        assert len(result) == 1
+        arguments = json.loads(result[0].function.arguments)
+        assert arguments["numbers"] == [10, 20, 30]
+        assert arguments["precision"] == 3
+    
+    def test_parse_with_surrounding_text(self):
+        """Test parsing XML tool calls with surrounding text."""
+        xml_text = """I need to check the weather and do some calculations.
+
+<tool_call>get_weather
+<arg_key>city</arg_key>
+<arg_value>Shanghai</arg_value>
+<arg_key>units</arg_key>
+<arg_value>metric</arg_value>
+</tool_call>
+
+Let me also calculate something:
+
+<tool_call>calculate_sum
+<arg_key>numbers</arg_key>
+<arg_value>[5, 10, 15]</arg_value>
+</tool_call>
+
+That should do it."""
+        
+        result = self.processor.parse_xml_to_json(xml_text, self.sample_tools)
+        
+        assert len(result) == 2
+        assert result[0].function.name == "get_weather"
+        assert result[1].function.name == "calculate_sum"
+    
+    def test_parse_malformed_xml(self):
+        """Test handling of malformed XML."""
+        malformed_xml = """<tool_call>get_weather
+<arg_key>city</arg_key>
+<arg_value>Beijing
+</tool_call>"""  # Missing closing tag for arg_value
+        
+        result = self.processor.parse_xml_to_json(malformed_xml, self.sample_tools)
+        
+        # Should create tool call but with empty arguments due to malformed arg_value
+        assert len(result) == 1
+        assert result[0].function.name == "get_weather"
+        arguments = json.loads(result[0].function.arguments)
+        assert arguments == {}  # Empty arguments due to malformed XML
+    
+    def test_empty_input(self):
+        """Test parsing empty input."""
+        result = self.processor.parse_xml_to_json("", self.sample_tools)
+        assert len(result) == 0
+    
+    def test_no_matching_tools(self):
+        """Test parsing with no matching tools in the tool list."""
+        xml_text = """<tool_call>unknown_function
+<arg_key>param</arg_key>
+<arg_value>value</arg_value>
+</tool_call>"""
+        
+        result = self.processor.parse_xml_to_json(xml_text, self.sample_tools)
+        
+        # Should still parse but with no type validation
+        assert len(result) == 1
+        assert result[0].function.name == "unknown_function"
+
+
+class TestXMLToolCallProcessorFactory:
+    """Test XML tool call processor factory."""
+    
+    def test_create_glm45_processor(self):
+        """Test creating GLM-4.5 processor."""
+        processor = XMLToolCallProcessorFactory.create_processor("glm45")
+        assert isinstance(processor, GLM45ToolCallProcessor)
+    
+    def test_create_glm45_processor_variations(self):
+        """Test creating GLM-4.5 processor with different name variations."""
+        for name in ["glm45", "glm-4.5", "GLM45", "GLM-4.5"]:
+            processor = XMLToolCallProcessorFactory.create_processor(name)
+            assert isinstance(processor, GLM45ToolCallProcessor)
+    
+    def test_create_unknown_processor(self):
+        """Test error handling for unknown processor type."""
+        with pytest.raises(ValueError, match="Unknown XML tool call processor type"):
+            XMLToolCallProcessorFactory.create_processor("unknown_processor")
+    
+    def test_get_available_processors(self):
+        """Test getting list of available processors."""
+        processors = XMLToolCallProcessorFactory.get_available_processors()
+        assert "glm45" in processors
+        assert "glm-4.5" in processors
+        assert "glm4" in processors
+
+
+class TestBaseXMLToolCallProcessor:
+    """Test base XML tool call processor functionality."""
+    
+    def test_parse_arguments_json(self):
+        """Test parsing JSON-formatted argument values."""
+        processor = GLM45ToolCallProcessor()  # Use concrete implementation
+        
+        # Test JSON parsing
+        result, success = processor._parse_arguments('{"key": "value"}')
+        assert success is True
+        assert result == {"key": "value"}
+        
+        # Test array parsing
+        result, success = processor._parse_arguments('[1, 2, 3]')
+        assert success is True
+        assert result == [1, 2, 3]
+        
+        # Test number parsing
+        result, success = processor._parse_arguments('42')
+        assert success is True
+        assert result == 42
+    
+    def test_parse_arguments_literal(self):
+        """Test parsing literal argument values."""
+        processor = GLM45ToolCallProcessor()
+        
+        # Test string that can't be parsed as JSON
+        result, success = processor._parse_arguments('simple_string')
+        assert success is False
+        assert result == 'simple_string'
+    
+    def test_get_argument_type(self):
+        """Test getting argument type from tool definition."""
+        processor = GLM45ToolCallProcessor()
+        tools = [
+            ToolSpec(
+                type="function",
+                function=Function(
+                    name="test_func",
+                    description="Test function",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "str_param": {"type": "string"},
+                            "int_param": {"type": "integer"}
+                        }
+                    }
+                )
+            )
+        ]
+        
+        assert processor._get_argument_type("test_func", "str_param", tools) == "string"
+        assert processor._get_argument_type("test_func", "int_param", tools) == "integer"
+        assert processor._get_argument_type("test_func", "unknown_param", tools) is None
+        assert processor._get_argument_type("unknown_func", "param", tools) is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_xml_tool_calls.py
+++ b/tests/test_xml_tool_calls.py
@@ -4,14 +4,14 @@ import pytest
 import json
 from endpoints.OAI.utils.xml_tool_processors import (
     GLM45ToolCallProcessor,
-    XMLToolCallProcessorFactory
+    XMLToolCallProcessorFactory,
 )
 from endpoints.OAI.types.tools import ToolCall, ToolSpec, Function
 
 
 class TestGLM45ToolCallProcessor:
     """Test GLM-4.5 XML tool call processor."""
-    
+
     def setup_method(self):
         """Set up test fixtures."""
         self.processor = GLM45ToolCallProcessor()
@@ -25,11 +25,17 @@ class TestGLM45ToolCallProcessor:
                         "type": "object",
                         "properties": {
                             "city": {"type": "string", "description": "City name"},
-                            "date": {"type": "string", "description": "Date in YYYY-MM-DD format"},
-                            "units": {"type": "string", "description": "Temperature units"}
-                        }
-                    }
-                )
+                            "date": {
+                                "type": "string",
+                                "description": "Date in YYYY-MM-DD format",
+                            },
+                            "units": {
+                                "type": "string",
+                                "description": "Temperature units",
+                            },
+                        },
+                    },
+                ),
             ),
             ToolSpec(
                 type="function",
@@ -39,14 +45,20 @@ class TestGLM45ToolCallProcessor:
                     parameters={
                         "type": "object",
                         "properties": {
-                            "numbers": {"type": "array", "description": "List of numbers"},
-                            "precision": {"type": "integer", "description": "Decimal precision"}
-                        }
-                    }
-                )
-            )
+                            "numbers": {
+                                "type": "array",
+                                "description": "List of numbers",
+                            },
+                            "precision": {
+                                "type": "integer",
+                                "description": "Decimal precision",
+                            },
+                        },
+                    },
+                ),
+            ),
         ]
-    
+
     def test_has_tool_call_positive(self):
         """Test detection of XML tool calls."""
         text_with_tool = """Some text before
@@ -55,15 +67,15 @@ class TestGLM45ToolCallProcessor:
 <arg_value>Beijing</arg_value>
 </tool_call>
 Some text after"""
-        
+
         assert self.processor.has_tool_call(text_with_tool) is True
-    
+
     def test_has_tool_call_negative(self):
         """Test when no tool calls are present."""
         text_without_tool = "This is just regular text with no tool calls."
-        
+
         assert self.processor.has_tool_call(text_without_tool) is False
-    
+
     def test_parse_single_tool_call(self):
         """Test parsing a single XML tool call."""
         xml_text = """<tool_call>get_weather
@@ -72,17 +84,17 @@ Some text after"""
 <arg_key>date</arg_key>
 <arg_value>2024-06-27</arg_value>
 </tool_call>"""
-        
+
         result = self.processor.parse_xml_to_json(xml_text, self.sample_tools)
-        
+
         assert len(result) == 1
         assert isinstance(result[0], ToolCall)
         assert result[0].function.name == "get_weather"
-        
+
         arguments = json.loads(result[0].function.arguments)
         assert arguments["city"] == "Beijing"
         assert arguments["date"] == "2024-06-27"
-    
+
     def test_parse_multiple_tool_calls(self):
         """Test parsing multiple XML tool calls."""
         xml_text = """<tool_call>get_weather
@@ -98,23 +110,23 @@ Some text after"""
 <arg_key>precision</arg_key>
 <arg_value>2</arg_value>
 </tool_call>"""
-        
+
         result = self.processor.parse_xml_to_json(xml_text, self.sample_tools)
-        
+
         assert len(result) == 2
-        
+
         # First tool call
         assert result[0].function.name == "get_weather"
         args1 = json.loads(result[0].function.arguments)
         assert args1["city"] == "Beijing"
         assert args1["date"] == "2024-06-27"
-        
+
         # Second tool call
         assert result[1].function.name == "calculate_sum"
         args2 = json.loads(result[1].function.arguments)
         assert args2["numbers"] == [1, 2, 3, 4, 5]
         assert args2["precision"] == 2
-    
+
     def test_parse_with_json_values(self):
         """Test parsing XML tool calls with JSON-formatted argument values."""
         xml_text = """<tool_call>calculate_sum
@@ -123,14 +135,14 @@ Some text after"""
 <arg_key>precision</arg_key>
 <arg_value>3</arg_value>
 </tool_call>"""
-        
+
         result = self.processor.parse_xml_to_json(xml_text, self.sample_tools)
-        
+
         assert len(result) == 1
         arguments = json.loads(result[0].function.arguments)
         assert arguments["numbers"] == [10, 20, 30]
         assert arguments["precision"] == 3
-    
+
     def test_parse_with_surrounding_text(self):
         """Test parsing XML tool calls with surrounding text."""
         xml_text = """I need to check the weather and do some calculations.
@@ -150,42 +162,42 @@ Let me also calculate something:
 </tool_call>
 
 That should do it."""
-        
+
         result = self.processor.parse_xml_to_json(xml_text, self.sample_tools)
-        
+
         assert len(result) == 2
         assert result[0].function.name == "get_weather"
         assert result[1].function.name == "calculate_sum"
-    
+
     def test_parse_malformed_xml(self):
         """Test handling of malformed XML."""
         malformed_xml = """<tool_call>get_weather
 <arg_key>city</arg_key>
 <arg_value>Beijing
 </tool_call>"""  # Missing closing tag for arg_value
-        
+
         result = self.processor.parse_xml_to_json(malformed_xml, self.sample_tools)
-        
+
         # Should create tool call but with empty arguments due to malformed arg_value
         assert len(result) == 1
         assert result[0].function.name == "get_weather"
         arguments = json.loads(result[0].function.arguments)
         assert arguments == {}  # Empty arguments due to malformed XML
-    
+
     def test_empty_input(self):
         """Test parsing empty input."""
         result = self.processor.parse_xml_to_json("", self.sample_tools)
         assert len(result) == 0
-    
+
     def test_no_matching_tools(self):
         """Test parsing with no matching tools in the tool list."""
         xml_text = """<tool_call>unknown_function
 <arg_key>param</arg_key>
 <arg_value>value</arg_value>
 </tool_call>"""
-        
+
         result = self.processor.parse_xml_to_json(xml_text, self.sample_tools)
-        
+
         # Should still parse but with no type validation
         assert len(result) == 1
         assert result[0].function.name == "unknown_function"
@@ -193,23 +205,23 @@ That should do it."""
 
 class TestXMLToolCallProcessorFactory:
     """Test XML tool call processor factory."""
-    
+
     def test_create_glm45_processor(self):
         """Test creating GLM-4.5 processor."""
         processor = XMLToolCallProcessorFactory.create_processor("glm45")
         assert isinstance(processor, GLM45ToolCallProcessor)
-    
+
     def test_create_glm45_processor_variations(self):
         """Test creating GLM-4.5 processor with different name variations."""
         for name in ["glm45", "glm-4.5", "GLM45", "GLM-4.5"]:
             processor = XMLToolCallProcessorFactory.create_processor(name)
             assert isinstance(processor, GLM45ToolCallProcessor)
-    
+
     def test_create_unknown_processor(self):
         """Test error handling for unknown processor type."""
         with pytest.raises(ValueError, match="Unknown XML tool call processor type"):
             XMLToolCallProcessorFactory.create_processor("unknown_processor")
-    
+
     def test_get_available_processors(self):
         """Test getting list of available processors."""
         processors = XMLToolCallProcessorFactory.get_available_processors()
@@ -220,35 +232,35 @@ class TestXMLToolCallProcessorFactory:
 
 class TestBaseXMLToolCallProcessor:
     """Test base XML tool call processor functionality."""
-    
+
     def test_parse_arguments_json(self):
         """Test parsing JSON-formatted argument values."""
         processor = GLM45ToolCallProcessor()  # Use concrete implementation
-        
+
         # Test JSON parsing
         result, success = processor._parse_arguments('{"key": "value"}')
         assert success is True
         assert result == {"key": "value"}
-        
+
         # Test array parsing
-        result, success = processor._parse_arguments('[1, 2, 3]')
+        result, success = processor._parse_arguments("[1, 2, 3]")
         assert success is True
         assert result == [1, 2, 3]
-        
+
         # Test number parsing
-        result, success = processor._parse_arguments('42')
+        result, success = processor._parse_arguments("42")
         assert success is True
         assert result == 42
-    
+
     def test_parse_arguments_literal(self):
         """Test parsing literal argument values."""
         processor = GLM45ToolCallProcessor()
-        
+
         # Test string that can't be parsed as JSON
-        result, success = processor._parse_arguments('simple_string')
+        result, success = processor._parse_arguments("simple_string")
         assert success is False
-        assert result == 'simple_string'
-    
+        assert result == "simple_string"
+
     def test_get_argument_type(self):
         """Test getting argument type from tool definition."""
         processor = GLM45ToolCallProcessor()
@@ -262,15 +274,17 @@ class TestBaseXMLToolCallProcessor:
                         "type": "object",
                         "properties": {
                             "str_param": {"type": "string"},
-                            "int_param": {"type": "integer"}
-                        }
-                    }
-                )
+                            "int_param": {"type": "integer"},
+                        },
+                    },
+                ),
             )
         ]
-        
+
         assert processor._get_argument_type("test_func", "str_param", tools) == "string"
-        assert processor._get_argument_type("test_func", "int_param", tools) == "integer"
+        assert (
+            processor._get_argument_type("test_func", "int_param", tools) == "integer"
+        )
         assert processor._get_argument_type("test_func", "unknown_param", tools) is None
         assert processor._get_argument_type("unknown_func", "param", tools) is None
 

--- a/tests/test_xml_tool_calls.py
+++ b/tests/test_xml_tool_calls.py
@@ -4,8 +4,7 @@ import pytest
 import json
 from endpoints.OAI.utils.xml_tool_processors import (
     GLM45ToolCallProcessor,
-    XMLToolCallProcessorFactory,
-    BaseXMLToolCallProcessor
+    XMLToolCallProcessorFactory
 )
 from endpoints.OAI.types.tools import ToolCall, ToolSpec, Function
 

--- a/tests/test_xml_tool_calls.py
+++ b/tests/test_xml_tool_calls.py
@@ -398,7 +398,7 @@ multiple lines
         assert "multiple lines" in arguments["description"]
 
     def test_parse_with_json_values(self):
-        """Test parsing Qwen3-coder XML tool calls with JSON-formatted parameter values."""
+        """Test parsing Qwen3-coder XML tool calls with JSON-formatted parameters."""
         xml_text = """<tool_call>
 <function=calculate_sum>
 <parameter=numbers>


### PR DESCRIPTION
## 🎯 Overview

This PR implements a comprehensive XML tool call processing system that enables both GLM-4.5 and Qwen3-coder models to work seamlessly with TabbyAPI's tool calling functionality. These models generate tool calls in different XML formats, but TabbyAPI expects OpenAI's JSON format. This implementation bridges that gap with a generic, extensible solution.

## 🚀 Key Features

- **Multi-Model Support**: Supports both GLM-4.5 and Qwen3-coder XML formats
- **Format Conversion**: Automatically converts XML tool calls to OpenAI JSON format
- **Extensible Architecture**: Generic XML processor system that can be extended for other XML-based models
- **Zero Breaking Changes**: Existing JSON tool calling functionality remains completely unchanged
- **Robust Error Handling**: Gracefully handles malformed XML and edge cases
- **Production Ready**: Comprehensive test coverage with 28 passing tests

## 📋 What's Changed

### Core Implementation

- **`endpoints/OAI/utils/xml_tool_processors.py`**
  - `BaseXMLToolCallProcessor`: Abstract base class for extensible XML processing
  - `GLM45ToolCallProcessor`: GLM-4.5 specific XML parser
  - `Qwen3CoderToolCallProcessor`: Qwen3-coder specific nested XML parser (supports "qwen3-coder" only)
  - `XMLToolCallProcessorFactory`: Factory pattern for creating appropriate processors

- **`common/templating.py`**
  - Added XML-specific metadata fields: `tool_call_format`, `xml_processor_type`, `tool_start`, `tool_end`, `stop_strings`
  - Extended `extract_metadata()` to handle complete XML configuration
  - Maintains backward compatibility with existing templates

- **`endpoints/OAI/utils/tools.py`**
  - Added `from_xml()` method for XML-specific processing
  - Added `from_text()` method for automatic format detection and routing
  - Fixed import issues with `Tool` class

- **`templates/tool_calls/qwen3-coder-tabbyapi.jinja`**
  - Complete TabbyAPI-compatible template with full XML metadata
  - Includes stop_strings, tool_start, tool_end, tool_call_format, xml_processor_type

### Quality Assurance

- **`tests/test_xml_tool_calls.py`**
  - 28 comprehensive test cases covering all functionality
  - Tests for GLM-4.5 format: single/multiple tool calls, JSON arguments, error handling
  - Tests for Qwen3-coder format: nested XML, multi-line parameters, attribute parsing
  - Factory tests with proper processor restrictions
  - **All tests passing** ✅

- **`docs/XML-Tool-Calling-Implementation.md`**
  - Complete implementation guide covering both GLM-4.5 and Qwen3-coder
  - Architecture explanation and troubleshooting section
  - Usage examples for both model types

## 🔧 Technical Details

### Supported XML Formats

**GLM-4.5 Format:**
```xml
<tool_call>get_weather
<arg_key>city</arg_key>
<arg_value>Beijing</arg_value>
<arg_key>units</arg_key>
<arg_value>metric</arg_value>
</tool_call>
```

**Qwen3-coder Format:**
```xml
<tool_call>
<function=get_weather>
<parameter=city>
Beijing
</parameter>
<parameter=units>
metric
</parameter>
</function>
</tool_call>
```

Both convert to OpenAI's JSON format:
```json
{
  "id": "call_123456789",
  "type": "function",
  "function": {
    "name": "get_weather",
    "arguments": "{\"city\": \"Beijing\", \"units\": \"metric\"}"
  }
}
```

### Architecture

- **Factory Pattern**: `XMLToolCallProcessorFactory` creates appropriate processors
- **Abstract Base Class**: `BaseXMLToolCallProcessor` enables easy extension for other models
- **Automatic Detection**: System automatically detects XML vs JSON format and routes accordingly
- **Type Safety**: Full integration with TabbyAPI's existing Pydantic models
- **Strict Separation**: Each processor only supports its specific model type

### Processor Restrictions

- **GLM-4.5**: Only supports `"glm45"` processor type
- **Qwen3-coder**: Only supports `"qwen3-coder"` processor type  
- **Regular Qwen3**: Does NOT use XML processing (different tool calling format)

## 🧪 Testing

```bash
# Run the XML tool call tests
python -m pytest tests/test_xml_tool_calls.py -v

# Results: 28 passed in 0.04s ✅
```

Test coverage includes:
- 9 GLM-4.5 processor tests
- 10 Qwen3-coder processor tests  
- 6 factory pattern tests
- 3 base class functionality tests

## 📖 Usage

### GLM-4.5 Models
```yaml
model:
  model_name: "path/to/glm-4.5-model"
  prompt_template: "tool_calls/glm-4p5-chat-template-tabbyapi"
```

### Qwen3-coder Models
```yaml
model:
  model_name: "path/to/qwen3-coder-model"
  prompt_template: "tool_calls/qwen3-coder-tabbyapi"
```

## 🔄 Backward Compatibility

- ✅ Existing JSON tool calling functionality unchanged
- ✅ All existing templates continue to work
- ✅ No breaking changes to existing APIs
- ✅ Graceful fallback for unsupported formats

## 🎉 Benefits

1. **Multi-Model Support**: Users can now use both GLM-4.5 and Qwen3-coder models with tool calling
2. **Future-Proof**: Architecture supports adding other XML-based models easily
3. **Robust**: Handles edge cases, malformed XML, and multi-line parameters gracefully
4. **Well-Tested**: Comprehensive test suite with 28 tests ensures reliability
5. **Documented**: Complete documentation for users and developers
6. **Strict Separation**: Clear boundaries between different model formats prevent conflicts

## 🔍 Files Changed

- `common/templating.py` - Enhanced template metadata system with complete XML support
- `endpoints/OAI/utils/tools.py` - Added XML processing capabilities with format detection
- `endpoints/OAI/utils/xml_tool_processors.py` - New XML processor system with GLM-4.5 and Qwen3-coder support
- `templates/tool_calls/qwen3-coder-tabbyapi.jinja` - New TabbyAPI-compatible Qwen3-coder template
- `tests/test_xml_tool_calls.py` - Comprehensive test suite covering both formats
- `docs/XML-Tool-Calling-Implementation.md` - Updated documentation covering both model types

This implementation successfully resolves XML tool calling compatibility for both GLM-4.5 and Qwen3-coder models while providing a solid foundation for supporting additional XML-based models in the future.