### PR TITLE
Unloading vision model of VLMs for Exllamav3 backend

### DIFF
--- a/backends/exllamav3/model.py
+++ b/backends/exllamav3/model.py
@@ -563,6 +563,10 @@ class ExllamaV3Container(BaseModelContainer):
                 self.draft_config = None
                 self.draft_cache = None
 
+            if self.use_vision:
+                self.vision_model.unload()
+                self.vision_model = None
+
             # Cleanup the generator from any pending jobs
             if self.generator is not None:
                 await self.generator.close()


### PR DESCRIPTION
This is a small PR that ensures that vision model of a VLM is unloaded and doesn't stay in VRAM indefinitely.

I've used a few exl3 VLMs and noticed that after unloading them a noticeable amount of VRAM was kept reserved by TabbyAPI.
Exl3 backend unload function was missing code to unload the vision part.

