### PR TITLE
Add FLA and dependencies to Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,6 @@
 # Use an official CUDA runtime with Ubuntu as a parent image
-FROM nvidia/cuda:12.8.1-runtime-ubuntu24.04
+FROM nvidia/cuda:12.8.1-devel-ubuntu24.04
 
-# Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     curl \
@@ -9,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3.12 \
     python3-pip \
     python3.12-venv \
+    python3.12-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Create a virtual environment
@@ -27,7 +27,7 @@ WORKDIR /app
 COPY pyproject.toml .
 
 # Install packages specified in pyproject.toml cu12, extras
-RUN pip install --no-cache-dir .[cu12,extras]
+RUN pip install --no-cache-dir .[cu12,extras] flash-linear-attention
 
 RUN rm pyproject.toml
 


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
Qwen3-Next-80B requires `flash-linear-attention`, which is not included in the current Dockerfile. FLA is not prebuilt, so some build dependencies are also needed to support pip FLA install.

**Why should this feature be added?**
Adds FLA to Dockerfile and therefore Qwen3-Next support.

