### PR TITLE
GPU selection specific to embedding models

### DIFF
--- a/backends/infinity/model.py
+++ b/backends/infinity/model.py
@@ -29,6 +29,11 @@ class InfinityContainer:
         # Extract device ID if specified
         device_id = kwargs.get("embeddings_device_id", [])
         
+        # Handle mixed device types (CPU/CUDA conflict)
+        if device == "cpu" and device_id:
+            logger.warning("embeddings_device is set to 'cpu' but embeddings_device_id is specified. Ignoring device_id and using CPU.")
+            device_id = []
+        
         # Validate device ID if using CUDA
         if device == "cuda" and device_id:
             if not isinstance(device_id, list):
@@ -36,27 +41,52 @@ class InfinityContainer:
             
             # Validate GPU exists
             available_gpus = torch.cuda.device_count()
+            valid_device_ids = []
+            
             for gpu_id in device_id:
                 if gpu_id >= available_gpus:
                     logger.error(f"GPU {gpu_id} not found. Available GPUs: 0-{available_gpus-1}")
-                    device_id = []  # Fallback to auto-select
-                    break
+                    continue  # Skip invalid GPU but continue checking others
+                else:
+                    valid_device_ids.append(gpu_id)
+            
+            # Use only valid device IDs
+            device_id = valid_device_ids
+            
+            # Handle multiple device IDs with infinity_emb compatibility
+            if len(device_id) > 1:
+                logger.warning("infinity_emb may not support multiple GPU IDs. Using first valid GPU: {device_id[0]}")
+                device_id = [device_id[0]]  # Use only first GPU
 
-        engine_args = EngineArgs(
-            model_name_or_path=str(self.model_dir),
-            engine="torch",
-            device=device,
-            device_id=device_id,  # Pass device ID to infinity_emb
-            bettertransformer=False,
-            model_warmup=False,
-        )
+        try:
+            engine_args = EngineArgs(
+                model_name_or_path=str(self.model_dir),
+                engine="torch",
+                device=device,
+                device_id=device_id,  # Pass device ID to infinity_emb
+                bettertransformer=False,
+                model_warmup=False,
+            )
 
-        self.engine = AsyncEmbeddingEngine.from_args(engine_args)
-        await self.engine.astart()
+            self.engine = AsyncEmbeddingEngine.from_args(engine_args)
+            await self.engine.astart()
 
-        self.loaded = True
-        gpu_info = f" on GPU {device_id}" if device_id else ""
-        logger.info(f"Embedding model successfully loaded{gpu_info}.")
+            self.loaded = True
+            gpu_info = f" on GPU {device_id}" if device_id else ""
+            logger.info(f"Embedding model successfully loaded{gpu_info}.")
+            
+        except RuntimeError as e:
+            if "out of memory" in str(e).lower():
+                logger.error(f"GPU {device_id} has insufficient memory for embedding model. Error: {str(e)}")
+                logger.error("Try using a different GPU or loading the model on CPU.")
+                raise
+            elif "cuda" in str(e).lower() or "device" in str(e).lower():
+                logger.error(f"Failed to load embedding model on GPU {device_id}. Error: {str(e)}")
+                logger.error("The GPU may be busy or unavailable. Try using a different GPU or CPU.")
+                raise
+            else:
+                logger.error(f"Unexpected error loading embedding model: {str(e)}")
+                raise
 
     async def unload(self):
         await self.engine.astop()

--- a/common/config_models.py
+++ b/common/config_models.py
@@ -420,6 +420,14 @@ class EmbeddingsConfig(BaseConfigModel):
             "If using an AMD GPU, set this value to 'cuda'."
         ),
     )
+    embeddings_device_id: Optional[List[int]] = Field(
+        [],
+        description=(
+            "Specific GPU device IDs for embedding models (default: []).\n"
+            "Empty list for auto-select.\n"
+            "Only applies when embeddings_device is 'cuda'."
+        ),
+    )
     embedding_model_name: Optional[str] = Field(
         None,
         description=("An initial embedding model to load on the infinity backend."),

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -218,6 +218,12 @@ embeddings:
   # If using an AMD GPU, set this value to 'cuda'.
   embeddings_device: cpu
 
+  # Specific GPU device IDs for embedding models (default: []).
+  # Empty list for auto-select.
+  # Only applies when embeddings_device is 'cuda'.
+  # Example: [0] for first GPU, [1] for second GPU
+  embeddings_device_id: []
+
   # An initial embedding model to load on the infinity backend.
   embedding_model_name:
 

--- a/docs/02.-Server-options.md
+++ b/docs/02.-Server-options.md
@@ -107,5 +107,12 @@ Note: Most of the options here will only apply on initial embedding model load/s
 | -------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | embedding_model_dir  | String ("models") | Directory to look for embedding models.<br><br>Note: Persisted across subsequent load requests                               |
 | embeddings_device    | String ("cpu")    | Device to load an embedding model on.<br><br>Options: cpu, cuda, auto<br><br>Note: Persisted across subsequent load requests |
-| embeddings_device_id | List[int] ([])    | Specific GPU device IDs for embedding models.<br><br>Empty list for auto-select.<br><br>Only applies when embeddings_device is "cuda". |
+| embeddings_device_id | List[int] ([])    | Specific GPU device IDs for embedding models.<br><br>Empty list for auto-select.<br><br>Only applies when embeddings_device is "cuda".<br><br>Note: If multiple GPUs are specified, only the first valid GPU will be used. |
 | embedding_model_name | String (None)     | Folder name of an embedding model to load using infinity-emb.                                                                |
+
+#### Troubleshooting
+
+- **GPU not found**: If you see "GPU X not found" error, check your GPU IDs against `nvidia-smi` output
+- **Out of memory**: If GPU runs out of memory, try using a different GPU or set `embeddings_device` to "cpu"
+- **GPU busy**: If model loading fails with CUDA errors, the GPU may be busy with other processes
+- **Mixed device types**: If `embeddings_device` is "cpu" but `embeddings_device_id` is set, the device ID will be ignored

--- a/docs/02.-Server-options.md
+++ b/docs/02.-Server-options.md
@@ -107,4 +107,5 @@ Note: Most of the options here will only apply on initial embedding model load/s
 | -------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | embedding_model_dir  | String ("models") | Directory to look for embedding models.<br><br>Note: Persisted across subsequent load requests                               |
 | embeddings_device    | String ("cpu")    | Device to load an embedding model on.<br><br>Options: cpu, cuda, auto<br><br>Note: Persisted across subsequent load requests |
+| embeddings_device_id | List[int] ([])    | Specific GPU device IDs for embedding models.<br><br>Empty list for auto-select.<br><br>Only applies when embeddings_device is "cuda". |
 | embedding_model_name | String (None)     | Folder name of an embedding model to load using infinity-emb.                                                                |

--- a/endpoints/core/types/model.py
+++ b/endpoints/core/types/model.py
@@ -123,6 +123,7 @@ class EmbeddingModelLoadRequest(BaseModel):
 
     # Set default from the config
     embeddings_device: Optional[str] = Field(config.embeddings.embeddings_device)
+    embeddings_device_id: Optional[List[int]] = Field(config.embeddings.embeddings_device_id)
 
 
 class ModelLoadResponse(BaseModel):


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
No ability to choose GPU while loading embedding models

**Why should this feature be added?**
In multi-GPU environments, TabbyAPI currently lacks the ability to specify which GPU device should be used for embedding models. This creates significant resource management challenges:

- **Current Limitation**: Embedding models automatically load on default GPU (typically GPU 0)
- **Resource Conflict**: Cannot distribute embedding workloads across available GPUs
- **Operational Inefficiency**: Forces users to manually manage GPU allocation via environment variables

**Examples**
In a multi-GPU cluster setup:
- GPU 3090: Running large language models (high memory usage)
- GPU 5090: Dedicated for embedding models (currently underutilized)
- Current TabbyAPI instance: Cannot target GPU 5090 for embeddings without restarting

**Additional context**
Added `embeddings_device_id` configuration parameter to enable specific GPU selection