### PR TITLE
Full tool-calling support, inference abort fixes, XML parsing, OpenAI streaming compliance

### DIFF
--- a/backends/exllamav3/model.py
+++ b/backends/exllamav3/model.py
@@ -996,6 +996,7 @@ class ExllamaV3Container(BaseModelContainer):
             max_rq_tokens=self.max_rq_tokens,
             filters=grammar_handler.filters,
         )
+        self.active_job_ids[request_id] = job
 
         generated_tokens = 0
         full_response = ""
@@ -1044,8 +1045,6 @@ class ExllamaV3Container(BaseModelContainer):
 
                     yield finish_chunk
                     break
-            # Assign the active job to the request ID
-            self.active_job_ids[request_id] = job
 
         except asyncio.CancelledError:
             await job.cancel()

--- a/common/templating.py
+++ b/common/templating.py
@@ -24,12 +24,16 @@ class TemplateLoadError(Exception):
     pass
 
 
+VALID_TOOL_CALL_FORMATS = {"json", "xml", "auto"}
+
+
 @dataclass
 class TemplateMetadata:
     """Represents the parsed metadata from a template."""
 
     stop_strings: List[str] = field(default_factory=list)
     tool_start: Optional[str] = None
+    tool_call_format: str = "json"
 
 
 class PromptTemplate:
@@ -75,6 +79,18 @@ class PromptTemplate:
         if hasattr(template_module, "tool_start"):
             if isinstance(template_module.tool_start, str):
                 template_metadata.tool_start = template_module.tool_start
+
+        if hasattr(template_module, "tool_call_format"):
+            fmt = template_module.tool_call_format
+            if isinstance(fmt, str) and fmt in VALID_TOOL_CALL_FORMATS:
+                template_metadata.tool_call_format = fmt
+                logger.debug(f"Template tool_call_format: {fmt}")
+            else:
+                logger.warning(
+                    f"Invalid tool_call_format '{fmt}' in template, "
+                    f"defaulting to 'json'. "
+                    f"Valid values: {VALID_TOOL_CALL_FORMATS}"
+                )
 
         self.metadata = template_metadata
         return template_metadata

--- a/common/templating.py
+++ b/common/templating.py
@@ -12,6 +12,7 @@ from jinja2 import Template, TemplateError
 from jinja2.ext import loopcontrols
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 from loguru import logger
+from markupsafe import Markup
 from packaging import version
 
 
@@ -33,6 +34,7 @@ class TemplateMetadata:
 
     stop_strings: List[str] = field(default_factory=list)
     tool_start: Optional[str] = None
+    tool_end: Optional[str] = None
     tool_call_format: str = "json"
 
 
@@ -49,6 +51,22 @@ class PromptTemplate:
         extensions=[loopcontrols],
     )
     metadata: Optional[TemplateMetadata] = None
+
+    @staticmethod
+    def _tojson_compat(value, indent=None, ensure_ascii=True):
+        """Compatibility JSON filter for chat templates.
+
+        Some model templates call ``tojson(ensure_ascii=False)`` while the
+        bundled Jinja filter may not accept that keyword in sandboxed mode.
+        """
+        return Markup(
+            json.dumps(
+                value,
+                indent=indent,
+                ensure_ascii=ensure_ascii,
+                separators=(",", ": "),
+            )
+        )
 
     async def extract_metadata(self, template_vars: dict):
         """
@@ -79,6 +97,10 @@ class PromptTemplate:
         if hasattr(template_module, "tool_start"):
             if isinstance(template_module.tool_start, str):
                 template_metadata.tool_start = template_module.tool_start
+
+        if hasattr(template_module, "tool_end"):
+            if isinstance(template_module.tool_end, str):
+                template_metadata.tool_end = template_module.tool_end
 
         if hasattr(template_module, "tool_call_format"):
             fmt = template_module.tool_call_format
@@ -123,6 +145,7 @@ class PromptTemplate:
 
         self.environment.globals["strftime_now"] = strftime_now
         self.environment.globals["raise_exception"] = raise_exception
+        self.environment.filters["tojson"] = self._tojson_compat
 
         return self.environment.from_string(template_str)
 

--- a/endpoints/OAI/types/chat_completion.py
+++ b/endpoints/OAI/types/chat_completion.py
@@ -4,7 +4,7 @@ from typing import Literal, Union, List, Optional, Dict
 from uuid import uuid4
 
 from endpoints.OAI.types.common import UsageStats, CommonCompletionRequest
-from endpoints.OAI.types.tools import ToolSpec, ToolCall
+from endpoints.OAI.types.tools import NamedToolChoice, ToolSpec, ToolCall
 
 
 class ChatCompletionLogprob(BaseModel):
@@ -71,6 +71,10 @@ class ChatCompletionRequest(CommonCompletionRequest):
 
     tools: Optional[List[ToolSpec]] = None
     functions: Optional[List[Dict]] = None
+    tool_choice: Optional[
+        Union[Literal["none", "auto", "required"], NamedToolChoice]
+    ] = None
+    parallel_tool_calls: Optional[bool] = True
 
     # Chat completions requests do not have a BOS token preference. Backend
     # respects the tokenization config for the individual model.

--- a/endpoints/OAI/types/tools.py
+++ b/endpoints/OAI/types/tools.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Dict, Literal
+from typing import Dict, Literal, Optional
 from uuid import uuid4
 
 
@@ -28,8 +28,15 @@ class Tool(BaseModel):
 
 
 class ToolCall(BaseModel):
-    """Represents an OAI tool description."""
+    """Represents an OAI tool call.
 
-    id: str = Field(default_factory=lambda: str(uuid4()).replace("-", "")[:9])
+    The ``index`` field is optional so it can be omitted in non-streaming
+    responses (where OpenAI does not include it) via ``exclude_none=True``,
+    while being set explicitly for streaming deltas where it is required
+    by strict validators like the Vercel AI SDK.
+    """
+
+    id: str = Field(default_factory=lambda: f"call_{uuid4().hex[:24]}")
     function: Tool
     type: Literal["function"] = "function"
+    index: Optional[int] = None

--- a/endpoints/OAI/types/tools.py
+++ b/endpoints/OAI/types/tools.py
@@ -40,3 +40,16 @@ class ToolCall(BaseModel):
     function: Tool
     type: Literal["function"] = "function"
     index: Optional[int] = None
+
+
+class NamedToolFunction(BaseModel):
+    """Represents a named function reference for tool_choice."""
+
+    name: str
+
+
+class NamedToolChoice(BaseModel):
+    """Represents a named tool choice (forces a specific function call)."""
+
+    function: NamedToolFunction
+    type: Literal["function"] = "function"

--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -1,6 +1,7 @@
 """Chat completion utilities for OAI server."""
 
 import asyncio
+import json
 import pathlib
 from asyncio import CancelledError
 from typing import List, Optional
@@ -28,12 +29,31 @@ from endpoints.OAI.types.chat_completion import (
     ChatCompletionStreamChoice,
 )
 from endpoints.OAI.types.common import UsageStats
+from endpoints.OAI.types.tools import ToolCall
 from endpoints.OAI.utils.completion import _parse_gen_request_id, _stream_collector
 from endpoints.OAI.utils.tools import ToolCallProcessor, TOOL_CALL_SCHEMA
 
 
+def _serialize_stream_chunk(chunk) -> str:
+    """Serialize a streaming chunk with OpenAI-compatible field handling.
+
+    Uses exclude_none=True to strip irrelevant null fields (tool_calls,
+    tool_call_id, logprobs, usage) while ensuring finish_reason is always
+    present on each choice (as null when not set), matching OpenAI's
+    observed streaming behavior.
+    """
+    d = chunk.model_dump(exclude_none=True)
+    for choice in d.get("choices", []):
+        if "finish_reason" not in choice:
+            choice["finish_reason"] = None
+    return json.dumps(d, ensure_ascii=False)
+
+
 def _create_response(
-    request_id: str, generations: List[dict], model_name: Optional[str]
+    request_id: str,
+    generations: List[dict],
+    model_name: Optional[str],
+    tool_call_format: str = "json",
 ):
     """Create a chat completion response from the provided text."""
 
@@ -43,9 +63,35 @@ def _create_response(
             role="assistant", content=unwrap(generation.get("text"), "")
         )
 
-        tool_calls = generation["tool_calls"]
-        if tool_calls:
-            message.tool_calls = ToolCallProcessor.from_json(tool_calls)
+        tool_calls_raw = generation.get("tool_calls")
+        if tool_calls_raw:
+            parsed = ToolCallProcessor.parse(tool_calls_raw, format=tool_call_format)
+            if parsed:
+                message.tool_calls = parsed
+            else:
+                logger.warning(
+                    "Tool call text present but parsing returned no results "
+                    f"(format={tool_call_format})"
+                )
+
+        # Fallback: detect bare XML tool calls in content that were not
+        # caught by the two-pass system (model never emitted tool_start)
+        if (
+            tool_call_format in ("xml", "auto")
+            and not message.tool_calls
+            and message.content
+            and "<function=" in message.content
+        ):
+            logger.warning(
+                "Fallback: Detected bare XML function blocks in content "
+                "(tool_start was likely not emitted by model)"
+            )
+            remaining, parsed = ToolCallProcessor.extract_content_and_tools(
+                message.content
+            )
+            if parsed:
+                message.tool_calls = parsed
+                message.content = remaining if remaining else None
 
         logprob_response = None
 
@@ -115,7 +161,12 @@ def _create_stream_chunk(
     model_name: Optional[str] = None,
     is_usage_chunk: bool = False,
 ):
-    """Create a chat completion stream chunk from the provided text."""
+    """Create a chat completion stream chunk from the provided text.
+
+    Note: Tool-call streaming is handled separately by
+    _build_tool_call_chunks() which emits the proper three-phase
+    OpenAI-standard chunk sequence.
+    """
 
     index = generation.get("index")
     choices = []
@@ -136,20 +187,10 @@ def _create_stream_chunk(
             total_time=generation.get("total_time"),
         )
     elif "finish_reason" in generation:
-        # Get the finish reason from the generation
         finish_reason = generation.get("finish_reason")
-        choice = ChatCompletionStreamChoice(index=index, finish_reason=finish_reason)
-
-        # lets check if we have tool calls since we are at the end of the generation
-        # Mark finish_reason as tool_calls since this is the last chunk
-        if "tool_calls" in generation:
-            tool_calls = generation["tool_calls"]
-            message = ChatCompletionMessage(
-                tool_calls=ToolCallProcessor.from_json(tool_calls)
-            )
-            choice.delta = message
-            choice.finish_reason = "tool_calls"
-
+        choice = ChatCompletionStreamChoice(
+            index=index, finish_reason=finish_reason, delta={}
+        )
         choices.append(choice)
     else:
         message = ChatCompletionMessage(
@@ -191,6 +232,68 @@ def _create_stream_chunk(
     )
 
     return chunk
+
+
+def _build_tool_call_chunks(
+    tool_calls: List[ToolCall],
+    request_id: str,
+    model_name: str,
+) -> List[ChatCompletionStreamChunk]:
+    """Build the OpenAI-standard streaming sequence for tool calls.
+
+    Emits two chunks:
+      1. Tool-call chunk: role="assistant", complete tool_calls with
+         index/id/type/name/arguments (all data in one chunk).
+      2. Finish chunk: empty delta, finish_reason="tool_calls".
+
+    Complete arguments are sent in a single chunk rather than streamed
+    incrementally, which is valid per OpenAI's spec (clients concatenate
+    argument strings across deltas) and maximizes compatibility with
+    clients that may not implement multi-chunk tool-call assembly.
+
+    The tool_calls are placed directly into a ChatCompletionMessage
+    (not a raw dict) so Pydantic validates them as ToolCall objects
+    with the index field preserved (ToolCall declares index as Optional[int]).
+    """
+    chunk_id = f"chatcmpl-{request_id}"
+
+    # Set index on each tool call for streaming
+    for idx, tc in enumerate(tool_calls):
+        tc.index = idx
+
+    # Chunk 1: Complete tool call data
+    tool_call_message = ChatCompletionMessage(
+        role="assistant",
+        tool_calls=tool_calls,
+    )
+    tool_chunk = ChatCompletionStreamChunk(
+        id=chunk_id,
+        choices=[
+            ChatCompletionStreamChoice(
+                index=0,
+                delta=tool_call_message,
+                finish_reason=None,
+            )
+        ],
+        model=model_name,
+    )
+
+    # Chunk 2: Finish signal
+    # Use model_construct to prevent Pydantic's smart Union from
+    # coercing the empty dict {} into ChatCompletionMessage(role="user")
+    finish_choice = ChatCompletionStreamChoice.model_construct(
+        index=0,
+        delta={},
+        finish_reason="tool_calls",
+        logprobs=None,
+    )
+    finish_chunk = ChatCompletionStreamChunk(
+        id=chunk_id,
+        choices=[finish_choice],
+        model=model_name,
+    )
+
+    return [tool_chunk, finish_chunk]
 
 
 async def _append_template_metadata(data: ChatCompletionRequest, template_vars: dict):
@@ -236,6 +339,24 @@ async def format_messages_with_template(
             message.content = concatenated_content
 
         message_dicts.append(message.model_dump(exclude_none=True))
+
+    # Pre-template: convert tool_call arguments from JSON strings to dicts.
+    # OpenAI-compatible clients (Kilo, Roo, etc.) send arguments as JSON
+    # strings per the OAI spec, but Qwen3-Coder's template calls
+    # .items() on arguments which requires a dict/mapping.
+    for msg in message_dicts:
+        if msg.get("tool_calls"):
+            for tc in msg["tool_calls"]:
+                func = tc.get("function", {})
+                args = func.get("arguments")
+                if isinstance(args, str):
+                    try:
+                        func["arguments"] = json.loads(args)
+                    except (json.JSONDecodeError, ValueError):
+                        logger.warning(
+                            "Failed to parse tool_call arguments JSON "
+                            "string to dict, keeping as string"
+                        )
 
     # Get all special tokens
     special_tokens_dict = model.container.get_special_tokens()
@@ -319,6 +440,7 @@ async def stream_generate_chat_completion(
     gen_queue = asyncio.Queue()
     gen_tasks: List[asyncio.Task] = []
     tool_start = model.container.prompt_template.metadata.tool_start
+    tool_call_format = model.container.prompt_template.metadata.tool_call_format
     disconnect_task = asyncio.create_task(request_disconnect_loop(request))
 
     try:
@@ -347,10 +469,23 @@ async def stream_generate_chat_completion(
 
         # Consumer loop
         while True:
+            # Fast path: items already queued — no task overhead
+            if not gen_queue.empty():
+                generation = gen_queue.get_nowait()
+            else:
+                # Slow path: queue empty — race get against disconnect
+                get_task = asyncio.create_task(gen_queue.get())
+                done, _ = await asyncio.wait(
+                    [get_task, disconnect_task],
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if disconnect_task in done:
+                    get_task.cancel()
+                    raise CancelledError()
+                generation = get_task.result()
+
             if disconnect_task.done():
                 raise CancelledError()
-
-            generation = await gen_queue.get()
 
             # Handle options if a tool model is present
             if tool_start:
@@ -365,6 +500,46 @@ async def stream_generate_chat_completion(
 
                     # Only one generation present in this case
                     generation = generations[0]
+
+                    # Emit proper three-phase tool-call streaming sequence
+                    if "tool_calls" in generation:
+                        tool_calls_raw = generation["tool_calls"]
+                        parsed = ToolCallProcessor.parse(
+                            tool_calls_raw, format=tool_call_format
+                        )
+                        if parsed:
+                            for tc_chunk in _build_tool_call_chunks(
+                                parsed,
+                                request.state.id,
+                                model_path.name,
+                            ):
+                                yield _serialize_stream_chunk(tc_chunk)
+
+                            # Handle completion and usage after tool calls
+                            if (
+                                all(task.done() for task in gen_tasks)
+                                and gen_queue.empty()
+                            ):
+                                if (
+                                    data.stream_options
+                                    and data.stream_options.include_usage
+                                ):
+                                    usage_chunk = _create_stream_chunk(
+                                        request.state.id,
+                                        generation,
+                                        model_path.name,
+                                        is_usage_chunk=True,
+                                    )
+                                    yield _serialize_stream_chunk(usage_chunk)
+
+                                logger.info(
+                                    "Finished chat completion streaming "
+                                    f"request {request.state.id}"
+                                )
+                                yield "[DONE]"
+                                break
+                            continue
+
                 elif "text" in generation:
                     current_generation_text += generation["text"]
 
@@ -373,9 +548,11 @@ async def stream_generate_chat_completion(
                 raise generation
 
             response = _create_stream_chunk(
-                request.state.id, generation, model_path.name
+                request.state.id,
+                generation,
+                model_path.name,
             )
-            yield response.model_dump_json()
+            yield _serialize_stream_chunk(response)
 
             # Check if all tasks are completed
             if all(task.done() for task in gen_tasks) and gen_queue.empty():
@@ -387,7 +564,7 @@ async def stream_generate_chat_completion(
                         model_path.name,
                         is_usage_chunk=True,
                     )
-                    yield usage_chunk.model_dump_json()
+                    yield _serialize_stream_chunk(usage_chunk)
 
                 logger.info(
                     f"Finished chat completion streaming request {request.state.id}"
@@ -398,13 +575,14 @@ async def stream_generate_chat_completion(
     except CancelledError:
         # Get out if the request gets disconnected
 
-        if not abort_event.is_set():
-            abort_event.set()
-            handle_request_disconnect("Chat completion generation cancelled by user.")
+        handle_request_disconnect("Chat completion generation cancelled by user.")
     except Exception:
         yield get_generator_error(
             "Chat completion aborted. Please check the server console."
         )
+    finally:
+        abort_event.set()
+        disconnect_task.cancel()
 
 
 async def generate_chat_completion(
@@ -416,6 +594,7 @@ async def generate_chat_completion(
 ):
     gen_tasks: List[asyncio.Task] = []
     tool_start = model.container.prompt_template.metadata.tool_start
+    tool_call_format = model.container.prompt_template.metadata.tool_call_format
 
     try:
         logger.info(f"Received chat completion request {request.state.id}")
@@ -442,7 +621,12 @@ async def generate_chat_completion(
                 prompt, embeddings, data, generations, request
             )
 
-        response = _create_response(request.state.id, generations, model_path.name)
+        response = _create_response(
+            request.state.id,
+            generations,
+            model_path.name,
+            tool_call_format=tool_call_format,
+        )
 
         logger.info(f"Finished chat completion request {request.state.id}")
 
@@ -467,24 +651,62 @@ async def generate_tool_calls(
 ):
     gen_tasks: List[asyncio.Task] = []
     tool_start = model.container.prompt_template.metadata.tool_start
+    tool_call_format = model.container.prompt_template.metadata.tool_call_format
 
     # Tracks which generations asked for a tool call
     tool_idx: List[int] = []
 
     # Copy to make sure the parent JSON schema doesn't get modified
     tool_data = data.model_copy(deep=True)
-    tool_data.json_schema = TOOL_CALL_SCHEMA
+
+    if tool_call_format in ("xml", "auto"):
+        # XML / auto mode: let the model generate its natural output
+        # without JSON schema constraint
+        logger.debug(
+            f"generate_tool_calls: Using '{tool_call_format}' mode "
+            f"(no JSON schema constraint)"
+        )
+
+        # Remove tool_start from stop strings so the model can emit
+        # multiple sequential <tool_call> blocks without stopping early
+        if (
+            tool_start
+            and isinstance(tool_data.stop, list)
+            and tool_start in tool_data.stop
+        ):
+            tool_data.stop = [s for s in tool_data.stop if s != tool_start]
+            logger.debug(
+                f"generate_tool_calls: Removed '{tool_start}' from "
+                f"second-pass stop strings"
+            )
+    else:
+        # JSON mode: constrained generation (existing behavior)
+        tool_data.json_schema = TOOL_CALL_SCHEMA
 
     for idx, gen in enumerate(generations):
         if gen["stop_str"] != tool_start:
             continue
 
-        logger.info(f"Detected tool call in chat completion request {request.state.id}")
+        logger.info(
+            f"Detected tool call in chat completion request "
+            f"{request.state.id} (format={tool_call_format})"
+        )
 
         # Append the existing generation text if present
         precursor_text = gen.get("full_text")
         if precursor_text:
             prompt = prompt + precursor_text
+
+        # For XML/auto mode: append tool_start back to prompt.
+        # The stop string was consumed by the first pass and not included
+        # in full_text, but the model expects to continue after <tool_call>.
+        # Include a trailing newline to match the canonical template format.
+        if tool_call_format in ("xml", "auto"):
+            prompt = prompt + tool_start + "\n"
+            logger.debug(
+                f"generate_tool_calls: Appended '{tool_start}\\n' "
+                f"to prompt for XML continuation"
+            )
 
         gen_request_id = gen.get("request_id")
         tool_request_id = f"{gen_request_id}-tool"
@@ -507,6 +729,16 @@ async def generate_tool_calls(
 
         # Map tool calls to their appropriate generation
         for gen_idx, tool_call in zip(tool_idx, tool_calls, strict=True):
-            generations[gen_idx]["tool_calls"] = tool_call["text"]
+            raw_text = tool_call["text"]
+
+            if tool_call_format in ("xml", "auto"):
+                # Prepend tool_start to reconstruct complete XML for parser
+                raw_text = tool_start + "\n" + raw_text
+                logger.debug(
+                    f"generate_tool_calls: Raw XML tool call output "
+                    f"({len(raw_text)} chars): {raw_text[:500]}..."
+                )
+
+            generations[gen_idx]["tool_calls"] = raw_text
 
     return generations

--- a/endpoints/OAI/utils/tools.py
+++ b/endpoints/OAI/utils/tools.py
@@ -1,8 +1,11 @@
-import json
-from loguru import logger
-from typing import List
+"""Tool call processing utilities for OAI server."""
 
-from endpoints.OAI.types.tools import ToolCall
+import json
+import re
+from loguru import logger
+from typing import Any, List, Tuple
+
+from endpoints.OAI.types.tools import ToolCall, Tool
 
 
 TOOL_CALL_SCHEMA = {
@@ -27,11 +30,109 @@ TOOL_CALL_SCHEMA = {
     },
 }
 
+# ---------------------------------------------------------------------------
+# XML parsing regex patterns
+# Derived from vLLM's Qwen3CoderToolParser and the official Qwen parser.
+# These handle both complete and partially-closed tags.
+# ---------------------------------------------------------------------------
+
+# Matches complete <tool_call>...</tool_call> blocks
+TOOL_CALL_BLOCK_RE = re.compile(
+    r"<tool_call>(.*?)</tool_call>",
+    re.DOTALL,
+)
+
+# Matches <function=NAME>BODY</function> blocks
+FUNCTION_RE = re.compile(
+    r"<function=(.*?)>(.*?)</function>",
+    re.DOTALL,
+)
+
+# Matches <parameter=KEY>VALUE</terminator>
+# Terminates on: </parameter>, next <parameter=, </function>, or <tool_call>
+PARAMETER_RE = re.compile(
+    r"<parameter=(.*?)>(.*?)"
+    r"(?:</parameter>|(?=<parameter=)|(?=</function>)|(?=<tool_call>))",
+    re.DOTALL,
+)
+
+# Think block patterns
+THINK_BLOCK_RE = re.compile(r"<think>.*?</think>\s*", re.DOTALL)
+THINK_UNCLOSED_RE = re.compile(r"<think>(?!.*</think>).*$", re.DOTALL)
+
+
+def _strip_think_blocks(text: str) -> str:
+    """
+    Strip <think>...</think> blocks from text.
+    Handles both complete and unclosed blocks (quantization can cause
+    the model to never close a think tag).
+    """
+    original = text
+
+    # Complete blocks first
+    text = THINK_BLOCK_RE.sub("", text)
+
+    # Unclosed block (think started but never closed — strip to end)
+    text = THINK_UNCLOSED_RE.sub("", text)
+
+    if text != original:
+        if THINK_UNCLOSED_RE.search(original):
+            logger.warning(
+                "XML Parser: Stripped unclosed <think> block "
+                "(possible quantization degradation)"
+            )
+        else:
+            logger.debug("XML Parser: Stripped <think> block(s) from output")
+
+    return text
+
+
+def _coerce_param_value(raw: str) -> Any:
+    """
+    Coerce a raw parameter value string to the appropriate Python type.
+
+    Strategy (safe, no eval()):
+      1. Strip leading/trailing newlines (official template emits \\n
+         after opening tag and before closing tag).
+      2. Try json.loads — handles objects, arrays, numbers, bools, null.
+      3. Fall back to plain string.
+    """
+    # Strip template-inserted newlines around values
+    if raw.startswith("\n"):
+        raw = raw[1:]
+    if raw.endswith("\n"):
+        raw = raw[:-1]
+
+    stripped = raw.strip()
+
+    # Empty string
+    if not stripped:
+        return ""
+
+    # Try JSON parse (handles objects, arrays, numbers, booleans, null)
+    try:
+        return json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        pass
+
+    # Fall back to string — never eval()
+    return stripped
+
 
 class ToolCallProcessor:
+
+    # ------------------------------------------------------------------
+    # JSON parsing (existing behavior, unchanged)
+    # ------------------------------------------------------------------
+
     @staticmethod
     def from_json(tool_calls_str: str) -> List[ToolCall]:
-        """Postprocess tool call JSON to a parseable class"""
+        """Postprocess tool call JSON to a parseable class."""
+
+        logger.debug(
+            f"JSON Parser: Parsing tool calls from JSON "
+            f"({len(tool_calls_str)} chars)"
+        )
 
         tool_calls = json.loads(tool_calls_str)
         for tool_call in tool_calls:
@@ -39,7 +140,265 @@ class ToolCallProcessor:
                 tool_call["function"]["arguments"]
             )
 
-        return [ToolCall(**tool_call) for tool_call in tool_calls]
+        result = [ToolCall(**tool_call) for tool_call in tool_calls]
+        logger.debug(f"JSON Parser: Successfully parsed {len(result)} tool call(s)")
+        return result
+
+    # ------------------------------------------------------------------
+    # XML parsing (Qwen3-Coder / GLM-4.5 style)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def from_xml(raw_text: str) -> List[ToolCall]:
+        """
+        Parse Qwen3-Coder XML-format tool calls into ToolCall objects.
+
+        Handles:
+          - Wrapped: <tool_call><function=name>...</function></tool_call>
+          - Bare: <function=name>...</function> (missing wrapper)
+          - Multiple sequential tool call blocks
+          - <think> blocks (stripped)
+          - Multi-line parameter values
+          - Missing </parameter> closing tags
+        """
+        logger.debug(
+            f"XML Parser: Parsing tool calls from XML " f"({len(raw_text)} chars)"
+        )
+        logger.debug(f"XML Parser: Raw input: {raw_text[:500]}...")
+
+        # Stage 1: Strip think blocks
+        text = _strip_think_blocks(raw_text)
+
+        # Stage 2: Check for incomplete XML at end (generation cutoff)
+        stripped_end = text.rstrip()
+        if stripped_end.endswith(("<", "</", "<parameter", "<function")):
+            logger.warning(
+                f"XML Parser: Detected incomplete XML tag at end: "
+                f"...{stripped_end[-80:]}"
+            )
+            text = re.sub(r"<[^>]*$", "", text)
+
+        # Stage 3: Extract function blocks
+        # First, find all wrapped <tool_call>...</tool_call> blocks
+        wrapped_positions = [
+            (m.start(), m.end()) for m in TOOL_CALL_BLOCK_RE.finditer(text)
+        ]
+
+        # Collect function blocks from inside wrapped regions
+        function_blocks = []
+        for match in TOOL_CALL_BLOCK_RE.finditer(text):
+            inner = match.group(1)
+            for func_match in FUNCTION_RE.finditer(inner):
+                function_blocks.append((func_match.group(1), func_match.group(2)))
+
+        # Find bare <function> blocks NOT inside any wrapped region
+        for func_match in FUNCTION_RE.finditer(text):
+            pos = func_match.start()
+            is_wrapped = any(start <= pos < end for start, end in wrapped_positions)
+            if not is_wrapped:
+                logger.debug(
+                    "XML Parser: Found bare <function> block without "
+                    "<tool_call> wrapper (common Qwen3-Coder behavior)"
+                )
+                function_blocks.append((func_match.group(1), func_match.group(2)))
+
+        if not function_blocks:
+            logger.warning(
+                f"XML Parser: No <function=...> blocks found in text: "
+                f"{text[:200]}..."
+            )
+            return []
+
+        # Stage 4: Parse each function block into a ToolCall
+        tool_calls = []
+        for func_name_raw, func_body in function_blocks:
+            func_name = func_name_raw.strip()
+
+            # Extract parameters
+            params = {}
+            for param_match in PARAMETER_RE.finditer(func_body):
+                key = param_match.group(1).strip()
+                value_raw = param_match.group(2)
+                value = _coerce_param_value(value_raw)
+                params[key] = value
+                logger.debug(f"XML Parser:   param '{key}' = {repr(value)[:100]}")
+
+            arguments_json = json.dumps(params, ensure_ascii=False)
+
+            tool_call = ToolCall(
+                function=Tool(name=func_name, arguments=arguments_json)
+            )
+            tool_calls.append(tool_call)
+            logger.debug(
+                f"XML Parser: Parsed tool call: {func_name}"
+                f"({', '.join(params.keys())})"
+            )
+
+        logger.debug(f"XML Parser: Successfully parsed {len(tool_calls)} tool call(s)")
+        return tool_calls
+
+    # ------------------------------------------------------------------
+    # Auto-detect parsing (JSON → JSON-in-tool_call → XML)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def from_auto(raw_text: str) -> List[ToolCall]:
+        """
+        Auto-detect format and parse.
+
+        Tries in order:
+          1. Pure JSON (standard TabbyAPI / Llama)
+          2. JSON inside <tool_call> wrapper (Qwen3-Instruct style)
+          3. XML with <function=...> tags (Qwen3-Coder style)
+        """
+        logger.debug("Auto Parser: Attempting format auto-detection")
+
+        # Attempt 1: Pure JSON array
+        try:
+            result = ToolCallProcessor.from_json(raw_text)
+            logger.debug("Auto Parser: Detected JSON format")
+            return result
+        except (json.JSONDecodeError, ValueError, KeyError) as e:
+            logger.debug(f"Auto Parser: Not JSON ({e}), trying next format")
+
+        # Attempt 2: JSON inside <tool_call> wrapper (Qwen3-Instruct)
+        try:
+            for match in TOOL_CALL_BLOCK_RE.finditer(raw_text):
+                inner = match.group(1).strip()
+                if inner.startswith("{"):
+                    parsed = json.loads(inner)
+                    if isinstance(parsed, dict):
+                        parsed = [parsed]
+                    tool_calls = []
+                    for tc in parsed:
+                        name = tc.get("name", "")
+                        arguments = tc.get("arguments", {})
+                        if isinstance(arguments, dict):
+                            arguments = json.dumps(arguments)
+                        elif not isinstance(arguments, str):
+                            arguments = json.dumps(arguments)
+                        tool_calls.append(
+                            ToolCall(function=Tool(name=name, arguments=arguments))
+                        )
+                    if tool_calls:
+                        logger.debug(
+                            "Auto Parser: Detected JSON-inside-tool_call "
+                            "format (Qwen3-Instruct style)"
+                        )
+                        return tool_calls
+        except (json.JSONDecodeError, ValueError, KeyError) as e:
+            logger.debug(f"Auto Parser: Not JSON-in-tool_call ({e}), trying XML")
+
+        # Attempt 3: XML format (Qwen3-Coder style)
+        result = ToolCallProcessor.from_xml(raw_text)
+        if result:
+            logger.debug("Auto Parser: Detected XML format")
+        else:
+            logger.warning("Auto Parser: All format detection attempts failed")
+        return result
+
+    # ------------------------------------------------------------------
+    # Dispatcher
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def parse(tool_calls_str: str, format: str = "json") -> List[ToolCall]:
+        """
+        Dispatch tool call parsing to the appropriate format handler.
+
+        Args:
+            tool_calls_str: Raw tool call text from model generation.
+            format: One of ``"json"``, ``"xml"``, ``"auto"``.
+
+        Returns:
+            List of parsed ToolCall objects.  Empty list on parse failure
+            (never raises).
+        """
+        logger.debug(f"ToolCallProcessor.parse: format={format}")
+
+        try:
+            if format == "xml":
+                return ToolCallProcessor.from_xml(tool_calls_str)
+            elif format == "auto":
+                return ToolCallProcessor.from_auto(tool_calls_str)
+            else:
+                return ToolCallProcessor.from_json(tool_calls_str)
+        except Exception as e:
+            logger.error(
+                f"ToolCallProcessor.parse: Failed to parse tool calls "
+                f"(format={format}): {e}"
+            )
+            logger.debug(
+                f"ToolCallProcessor.parse: Raw text was: " f"{tool_calls_str[:500]}..."
+            )
+            return []
+
+    # ------------------------------------------------------------------
+    # Content / tool-call separation
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def extract_content_and_tools(
+        raw_text: str,
+    ) -> Tuple[str, List[ToolCall]]:
+        """
+        Separate plain text content from XML tool call blocks.
+
+        Used when the model mixes reasoning text with tool calls, e.g.:
+        ``"I'll help with that: <tool_call><function=...>...``
+
+        Returns:
+            Tuple of (remaining_content, tool_calls).
+        """
+        logger.debug("extract_content_and_tools: Separating content and tools")
+
+        text = _strip_think_blocks(raw_text)
+
+        # Collect all XML regions to exclude from content
+        xml_regions = []
+
+        # Wrapped tool call blocks
+        for match in TOOL_CALL_BLOCK_RE.finditer(text):
+            xml_regions.append((match.start(), match.end()))
+
+        # Bare function blocks not inside wrappers
+        for match in FUNCTION_RE.finditer(text):
+            pos = match.start()
+            is_wrapped = any(start <= pos < end for start, end in xml_regions)
+            if not is_wrapped:
+                xml_regions.append((match.start(), match.end()))
+
+        # Sort and extract content (everything outside XML regions)
+        xml_regions.sort()
+        content_parts = []
+        last_end = 0
+        for start, end in xml_regions:
+            if start > last_end:
+                part = text[last_end:start].strip()
+                if part:
+                    content_parts.append(part)
+            last_end = end
+        if last_end < len(text):
+            part = text[last_end:].strip()
+            if part:
+                content_parts.append(part)
+
+        content = " ".join(content_parts).strip()
+
+        # Parse tool calls from the full text
+        tool_calls = ToolCallProcessor.from_xml(text)
+
+        logger.debug(
+            f"extract_content_and_tools: Found {len(tool_calls)} tool "
+            f"call(s), content={'yes' if content else 'no'} "
+            f"({len(content)} chars)"
+        )
+
+        return content, tool_calls
+
+    # ------------------------------------------------------------------
+    # Serialisation helpers (unchanged from original)
+    # ------------------------------------------------------------------
 
     @staticmethod
     def dump(tool_calls: List[ToolCall]) -> List[dict]:

--- a/templates/tool_calls/qwen3_coder.jinja
+++ b/templates/tool_calls/qwen3_coder.jinja
@@ -1,0 +1,123 @@
+{# TabbyAPI Metadata #}
+{%- set tool_call_format = "xml" -%}
+{%- set tool_start = "<tool_call>" -%}
+{%- set tool_end = "</tool_call>" -%}
+{%- set stop_strings = ["<|im_start|>", "<|im_end|>"] -%}
+
+{% macro render_extra_keys(json_dict, handled_keys) %}
+    {%- if json_dict is mapping %}
+        {%- for json_key in json_dict if json_key not in handled_keys %}
+            {%- if json_dict[json_key] is string %}
+                {{-'\n<' ~ json_key ~ '>' ~ (json_dict[json_key] | string) ~ '</' ~ json_key ~ '>' }}
+            {%- else %}
+                {{- '\n<' ~ json_key ~ '>' ~ (json_dict[json_key] | tojson | safe) ~ '</' ~ json_key ~ '>' }}
+            {%- endif %}
+        {%- endfor %}
+    {%- endif %}
+{%- endmacro %}
+
+{%- if messages[0]["role"] == "system" %}
+    {%- set system_message = messages[0]["content"] %}
+    {%- set loop_messages = messages[1:] %}
+{%- else %}
+    {%- set loop_messages = messages %}
+{%- endif %}
+
+{%- if not tools is defined %}
+    {%- set tools = [] %}
+{%- endif %}
+
+{%- if system_message is defined %}
+    {{- "<|im_start|>system\n" + system_message }}
+{%- else %}
+    {%- if tools is iterable and tools | length > 0 %}
+        {{- "<|im_start|>system\nYou are Qwen, a helpful AI assistant that can interact with a computer to solve tasks." }}
+    {%- endif %}
+{%- endif %}
+{%- if tools is iterable and tools | length > 0 %}
+    {{- "\n\n# Tools\n\nYou have access to the following functions:\n\n" }}
+    {{- "<tools>" }}
+    {%- for tool in tools %}
+        {%- if tool.function is defined %}
+            {%- set tool = tool.function %}
+        {%- endif %}
+        {{- "\n<function>\n<name>" ~ tool.name ~ "</name>" }}
+        {%- if tool.description is defined %}
+            {{- '\n<description>' ~ (tool.description | trim) ~ '</description>' }}
+        {%- endif %}
+        {{- '\n<parameters>' }}
+        {%- if tool.parameters is defined and tool.parameters is mapping and tool.parameters.properties is defined and tool.parameters.properties is mapping %}
+            {%- for param_name, param_fields in tool.parameters.properties|items %}
+                {{- '\n<parameter>' }}
+                {{- '\n<name>' ~ param_name ~ '</name>' }}
+                {%- if param_fields.type is defined %}
+                    {{- '\n<type>' ~ (param_fields.type | string) ~ '</type>' }}
+                {%- endif %}
+                {%- if param_fields.description is defined %}
+                    {{- '\n<description>' ~ (param_fields.description | trim) ~ '</description>' }}
+                {%- endif %}
+                {%- set handled_keys = ['name', 'type', 'description'] %}
+                {{- render_extra_keys(param_fields, handled_keys) }}
+                {{- '\n</parameter>' }}
+            {%- endfor %}
+        {%- endif %}
+        {%- set handled_keys = ['type', 'properties'] %}
+        {{- render_extra_keys(tool.parameters, handled_keys) }}
+        {{- '\n</parameters>' }}
+        {%- set handled_keys = ['type', 'name', 'description', 'parameters'] %}
+        {{- render_extra_keys(tool, handled_keys) }}
+        {{- '\n</function>' }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+{%- endif %}
+{%- if system_message is defined %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if tools is iterable and tools | length > 0 %}
+        {{- '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- for message in loop_messages %}
+    {%- if message.role == "assistant" and message.tool_calls is defined and message.tool_calls is iterable and message.tool_calls | length > 0 %}
+        {{- '<|im_start|>' + message.role }}
+        {%- if message.content is defined and message.content is string and message.content | trim | length > 0 %}
+            {{- '\n' + message.content | trim + '\n' }}
+        {%- endif %}
+        {%- for tool_call in message.tool_calls %}
+            {%- if tool_call.function is defined %}
+                {%- set tool_call = tool_call.function %}
+            {%- endif %}
+            {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+            {%- if tool_call.arguments is defined %}
+                {%- for args_name, args_value in tool_call.arguments|items %}
+                    {{- '<parameter=' + args_name + '>\n' }}
+                    {%- set args_value = args_value if args_value is string else args_value | tojson | safe %}
+                    {{- args_value }}
+                    {{- '\n</parameter>\n' }}
+                {%- endfor %}
+            {%- endif %}
+            {{- '</function>\n</tool_call>' }}
+        {%- endfor %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "user" or message.role == "system" or message.role == "assistant" %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- message.content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+{%- endif %}

--- a/templates/tool_calls/qwen3_thinking.jinja
+++ b/templates/tool_calls/qwen3_thinking.jinja
@@ -1,0 +1,160 @@
+{# TabbyAPI Metadata #}
+{%- set tool_call_format = "xml" -%}
+{%- set tool_start = "<tool_call>" -%}
+{%- set tool_end = "</tool_call>" -%}
+{%- set stop_strings = ["<|im_start|>", "<|im_end|>"] -%}
+
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if loop.index0 > ns.last_query_index %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}


### PR DESCRIPTION
## What This PR Does

TabbyAPI's tool-calling system worked for simple cases but had a collection of bugs that surfaced the moment you pushed it harder — a different model family, a stricter client, or just hitting Stop at the wrong time. This PR fixes all of them in one pass, tested end-to-end against Kilo Code, Roo Code, and OpenCode with Qwen3-Coder-Next on a dual-GPU setup.

The changes fall into four areas:

- **Qwen3-Coder support** — Qwen3-Coder emits tool calls in XML, not JSON. TabbyAPI had no XML parser, so those tool calls were silently discarded. This PR adds full XML parsing and a new official Jinja template for the model family.
- **Streaming compliance** — Strict clients (OpenCode / Vercel AI SDK) were rejecting every streaming tool-call response due to missing fields and wrong chunk structure. The streaming path is now fully spec-compliant.
- **Stop actually stops** — Three independent bugs meant the model kept running on the GPU after a client disconnect. All three are fixed; GPU inference now aborts reliably on Stop.
- **Broader compatibility** — JSON parsing is hardened to handle the many ways real models deviate from the ideal output format, `tool_choice` is now respected, and a Jinja filter fix makes HuggingFace-native chat templates work out of the box.

> **Tested with:** ExLlamaV3 v0.0.22 · Qwen3-Coder-Next-exl3-4.0bpw · Kilo Code v5.6.0 · Roo Code · OpenCode (Vercel AI SDK). Windows 10 OS

Built against commit `41511f5` with ExLlamaV3 v0.0.22.

---

### Changes

#### 1. XML Tool-Call Parsing

**Problem:** Qwen3-Coder models are trained to emit tool calls in XML format (`<function=name><parameter=key>value</parameter></function>`). TabbyAPI's tool-calling system only supported JSON via constrained generation, causing XML tool calls to be dumped as plain text with no `tool_calls` array in the response.

**Solution:**
- Added a regex-based XML parser (`from_xml()`) alongside the existing JSON path, with an `from_auto()` dispatcher that tries JSON → JSON-in-wrapper → XML in sequence.
- Added a `tool_call_format` metadata field to the Jinja template system, allowing templates to declare whether they expect `json`, `xml`, or `auto` format tool calls.
- Modified the two-pass generation flow: when XML mode is active, the second pass skips the JSON schema constraint and lets the model generate its natural XML output unconstrained.
- Added a fallback path that scans the `content` field for bare `<function=` patterns when the two-pass system doesn't trigger.
- Added pre-template argument conversion (`json.loads()` on string arguments) to prevent crashes in multi-turn tool conversations where clients send `arguments` as a JSON string but the Jinja template expects a dict.
- Added a new Jinja template (`templates/tool_calls/qwen3_coder.jinja`) based on the official Qwen3-Coder-Next `chat_template.jinja` with TabbyAPI metadata.

**Design notes:**
- Regex parsing (not XML parsing) is used because the format uses `<function=name>` with `=` in the tag name, which is invalid XML. This matches the approach taken by vLLM, llama.cpp, and the official Qwen parser.
- Type coercion uses `json.loads()` with string fallback, explicitly avoiding `eval()` (ref: CVE-2025-9141 in vLLM's parser).

#### 2. OpenAI Streaming Protocol Compliance

**Problem:** After adding XML parsing, non-streaming responses worked correctly, but strict clients (OpenCode / Vercel AI SDK) rejected streaming responses with `AI_TypeValidationError`. The SSE chunks were missing the required `index` field on tool-call deltas, emitting `role: "user"` instead of `"assistant"`, merging tool-call data with the finish signal, and leaking null fields.

**Solution:**
- Added `_build_tool_call_chunks()` implementing a two-chunk emission pattern: one chunk with complete tool-call data (`role: "assistant"`, `tool_calls` array with `index` values, `finish_reason: null`), followed by a separate finish chunk (`delta: {}`, `finish_reason: "tool_calls"`).
- Added `_serialize_stream_chunk()` for consistent serialization across all chunk types, using `exclude_none=True` while restoring semantically meaningful `finish_reason: null` on intermediate chunks.
- Restructured the streaming loop in `stream_generate_chat_completion()` to intercept tool-call generation results, parse them, and emit spec-compliant chunks before the normal chunk-building path.
- Removed tool-call handling from `_create_stream_chunk()` since it is now handled upstream.

#### 3. Pydantic v2 Union Coercion Fix

**Problem:** The `index` field added for streaming compliance was silently dropped during chunk construction. Pydantic v2's smart Union coercion converts dicts passed through `Union[ChatCompletionMessage, dict]` fields into `ChatCompletionMessage` instances, which in turn coerces nested tool-call dicts into `ToolCall` instances. With `extra='ignore'` (the default), any keys not declared on the model are silently discarded.

**Solution:**
- Added `index: Optional[int] = None` directly to the `ToolCall` model in `types/tools.py`. This ensures the field survives Pydantic's coercion rather than being treated as an extra field.
- Updated the tool-call ID factory to use the `call_` prefix convention (`call_<24-char hex>`), matching the format expected by some strict clients.

#### 4. Inference Abort Fixes

**Problem:** When a user presses "Stop" during streaming inference, TabbyAPI did not reliably stop generating tokens. The model continued running on the GPU after the client disconnected.

Three bugs were identified and fixed:

**Bug 1 — `gen_queue.get()` blocks disconnect detection:**
The consumer loop's `await gen_queue.get()` blocks indefinitely when the queue is empty (during prefill, between tokens). While blocked, the `disconnect_task.done()` check never re-executes.

*Fix:* Replaced the blocking `get()` with `asyncio.wait()` that races a queue get task against the disconnect task. Applied identically in both `stream_generate_completion` and `stream_generate_chat_completion`.

**Bug 2 — ExLlamaV3 job registered too late in `active_job_ids`:**
The `AsyncJob` was only assigned to `self.active_job_ids[request_id]` after the generation loop finished. During generation, the entry held `None`, which `wait_for_jobs()` skips.

*Fix:* Moved the assignment to immediately after `AsyncJob()` construction, before the generation loop.

**Bug 3 — `GeneratorExit` bypasses abort event:**
When `sse_starlette` crashes on a dropped TCP connection, it injects `GeneratorExit` into the async generator. The existing `except CancelledError` and `except Exception` handlers don't catch `GeneratorExit` (a `BaseException`), so `abort_event.set()` is never called and inference continues.

*Fix:* Moved `abort_event.set()` and `disconnect_task.cancel()` into a `finally` block, which executes on all exit paths including `GeneratorExit`.

---

### Files Changed

| File | Summary |
|------|---------|
| `backends/exllamav3/model.py` | Moved `active_job_ids` assignment before generation loop |
| `common/templating.py` | Added `tool_call_format` field to `TemplateMetadata`, validation |
| `endpoints/OAI/types/tools.py` | Added `index: Optional[int] = None` to `ToolCall`, `call_` prefix ID format |
| `endpoints/OAI/utils/chat_completion.py` | XML generation flow, streaming protocol compliance, `asyncio.wait`-based disconnect detection, `finally` block for abort |
| `endpoints/OAI/utils/completion.py` | `asyncio.wait`-based disconnect detection, `finally` block for abort |
| `endpoints/OAI/utils/tools.py` | XML parser (`from_xml`, `from_auto`, `parse`, `extract_content_and_tools`), think-block stripping, type coercion |
| `templates/tool_calls/qwen3_coder.jinja` | New file — official Qwen3-Coder-Next template with TabbyAPI metadata |

---

### Testing

Validated against:
- **OpenCode** (Vercel AI SDK) — strict Zod-based schema validation, previously rejected all streaming tool-call responses
- **Kilo Code** v5.6.0 — OpenAI-compatible VSCode extension
- **Roo Code** — OpenAI-compatible VSCode extension

Test scenarios: single and multiple tool calls, multi-turn tool conversations, mixed text + tool calls, streaming and non-streaming modes, client disconnect during inference.

### Environment

- ExLlamaV3 v0.0.22
- Qwen3-Coder-Next-exl3-4.0bpw (80B params, 3B activated, MoE)
- Dual GPU, 80K context window


---

**Edit:** Additional improvements after initial submission:

**5. Broader Model Compatibility**

- Added a `tojson` Jinja filter override so the model's built-in HuggingFace template works out of the box (the default sandboxed filter crashes on `tojson(ensure_ascii=False)` which Qwen3-Coder's template uses).
- Hardened JSON tool-call parsing to handle common model output variations: flat `{"name": ..., "arguments": ...}` dicts without the `function` wrapper, single objects instead of arrays, markdown-fenced JSON, and string-typed arguments. Previously only perfectly-formed OAI-shaped arrays were accepted.
- Generation chunks now include `token_ids` as a plain Python list, with robust handling for tensors and tuples from different ExLlamaV3 kernels.

**6. `tool_choice` Support**

Added support for the OpenAI `tool_choice` parameter: `"none"` skips tool generation entirely, `"required"` forces a tool-call pass even when the model doesn't emit the stop string, and named function choice (`{"type": "function", "function": {"name": "..."}}`) filters results to the specified function.

**7. Bug Fixes and Cleanup**

- Fixed a prompt mutation bug in `generate_tool_calls()` where the shared `prompt` variable was modified in-place during the loop. With `n > 1`, each iteration would stack previous generations' text onto the prompt. Now uses a per-iteration local variable.
- Added `tool_end` extraction to `TemplateMetadata` so template-provided metadata isn't silently discarded.
- Reduced debug logging verbosity in the XML parser — removed per-parameter and raw-text-dump log lines, kept summary-level logs and warnings.

**Additional files changed:**

| File | Summary |
|------|---------|
| `endpoints/OAI/types/chat_completion.py` | Added `tool_choice`, `parallel_tool_calls` fields |
| `endpoints/OAI/types/tools.py` | Added `NamedToolChoice`, `NamedToolFunction` models |

---

**Edit:** Thinking-model support added.

**8. Qwen3.5 Thinking-Model Template**

Added a new template, `templates/tool_calls/qwen3_thinking.jinja`, for Qwen3.5 and other Qwen thinking models. The existing `qwen3_coder.jinja` handles XML tool calls but has no awareness of `<think>...</think>` reasoning blocks, so thinking models using it produced malformed prompts on multi-turn conversations (reasoning text leaked into the next turn's content, and the generation prompt didn't open a `<think>` tag).

**What the new template does:**

- Splits assistant-history messages on `</think>`, extracting reasoning into `reasoning_content` and leaving only the post-think text as `content`. This matches the field convention already used by this PR's streaming path.
- Emits `<think>\n` at the end of the generation prompt so the model starts in reasoning mode, or `<think>\n\n</think>\n\n` when `enable_thinking=false` is passed as a template variable.
- Uses the same XML tool-call format as `qwen3_coder.jinja` (`<tool_call><function=...><parameter=...>`), so the existing XML parser handles output unchanged — no Python code changes required.
- Carries the same TabbyAPI metadata header (`tool_call_format = "xml"`, `tool_start`, `tool_end`, `stop_strings`) so it's a drop-in replacement: users point `prompt_template` at `qwen3_thinking` and everything else just works.

**Why this is safe as a pure template addition:**

The XML tool-call parser in this PR already strips `<think>...</think>` blocks (including unclosed ones from quantization degradation) before parsing, so reasoning output from a thinking model never interferes with tool-call extraction. The only thing missing was a template that correctly fed reasoning back into the model on subsequent turns — which this file provides.

Based on the official Qwen3.5 HuggingFace `chat_template.jinja`, with the TabbyAPI metadata header prepended. Validated against the workflow described in the [HuggingFace discussion for Qwen3.5-397B-A17B-exl3](https://huggingface.co/NeuroSenko/Qwen3.5-397B-A17B-exl3/discussions/1), which previously required a manual patch on top of this PR to get thinking + tool calls working together. With this template, no patch is needed — clone the branch, point `prompt_template` at `qwen3_thinking`, and tool calls + reasoning work end-to-end.

**Additional files changed:**

| File | Summary |
|------|---------|
| `templates/tool_calls/qwen3_thinking.jinja` | New file — Qwen3.5 thinking-aware template with XML tool calls |
