### PR TITLE
fix(docker): prevent xformers from pulling cu130 wheels on cu128 hosts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -26,8 +26,13 @@ WORKDIR /app
 # Get requirements
 COPY pyproject.toml .
 
-# Install packages specified in pyproject.toml cu12, extras
-RUN pip install --no-cache-dir .[cu12,extras]
+# Install cu12 group first — pins torch+cu128, exllamav2/v3+cu128, flash_attn+cu128.
+# The 'extras' group (infinity-emb, sentence-transformers) is installed separately
+# with --no-deps so pip cannot resolve xformers transitively and pull a cu130 wheel,
+# which would cause libcudart.so.13 ImportError on driver 590.x (cu128-only hosts).
+# See: https://github.com/theroyallab/tabbyAPI/issues/414
+RUN pip install --no-cache-dir .[cu12]
+RUN pip install --no-cache-dir --no-deps .[extras]
 
 RUN rm pyproject.toml
 


### PR DESCRIPTION
## Summary

The default \`pip install .[cu12,extras]\` lets pip resolve \`xformers\` transitively (via \`infinity-emb\` / \`sentence-transformers\` in the \`extras\` group). When pip resolves \`xformers\`, it can pull a **cu130**-aligned wheel that requires \`libcudart.so.13\`. On hosts with NVIDIA driver 590.x (cu128-only), this fails at import time:

\`\`\`
ImportError: libcudart.so.13: cannot open shared object file
\`\`\`

This breaks any deployment using the \`ghcr.io/theroyallab/tabbyapi:latest\` image on cu128-driver hosts — the container crash-loops at module import.

## Reproduction

Reproduced on a K3s cluster: 12 exllamav2/exllamav3 deployment pods × 6 hosts, all crash-looped on the \`:latest\` image (sha \`bd61504c…\`). Trace: \`xformers\` → imports \`flash_attn_3\` → requires \`libcudart.so.13\` (cu130). The container's runtime is cu128 (NVIDIA driver 590.48.01-open + base image \`nvidia/cuda:12.8.1-runtime-ubuntu24.04\` + \`torch 2.9.0+cu128\`).

The current \`main\` branch's \`pyproject.toml\` is cu128-aligned end-to-end (\`torch\`, \`exllamav2\`, \`exllamav3\`, \`flash_attn\` all pin cu128 wheels). The transitive resolution of \`xformers\` is the only path that breaks the cu128 lock.

## Fix

Split the install into two pip invocations:

1. \`pip install .[cu12]\` — locks \`torch\` + cu128 wheels for \`exllamav2\` / \`exllamav3\` / \`flash_attn\`.
2. \`pip install --no-deps .[extras]\` — installs \`infinity-emb\` / \`sentence-transformers\` without pulling any transitive dep, so pip cannot resolve \`xformers\` outside the cu128 lock.

The \`extras\` group provides functionality that doesn't strictly need its transitive deps to be solved at install time (sentence-transformers and friends are runtime-loaded; the cu128 \`torch\` already in the env is sufficient).

## Test plan

- [x] Tested on Hydra K3s cluster (NVIDIA 590.48.01-open + cu128 base image + \`torch 2.9.0+cu128\`)
- [x] All 12 exllamav2/v3 deployments now import cleanly and serve /v1/models
- [ ] Reviewer can verify by building the Dockerfile on a cu128-only host and running \`docker run … --gpus all … python -c "import xformers; xformers.ops.memory_efficient_attention"\`

## Related

- Tracked locally as \`scoobydont-666/hydra-project#276\`
- Hydra cluster vendored \`main\` on 2026-05-03; this fix has been running in production on 12 deployment pods since.