### PR TITLE
Start.py: improve dependency installation check and cleanup uv logging

### DIFF
--- a/start.py
+++ b/start.py
@@ -173,7 +173,7 @@ def run_pip(command: List[str]):
     if has_uv:
         command.insert(0, "uv")
 
-    subprocess.run(command)
+    subprocess.run(command, check=True)
 
 
 if __name__ == "__main__":
@@ -198,8 +198,11 @@ if __name__ == "__main__":
     add_start_args(parser)
     args, _ = parser.parse_known_args()
 
-    # Log pip version
-    run_pip(["pip", "-V"])
+    # Log pip/uv version
+    if has_uv:
+        subprocess.run(["uv", "-V"])
+    else:
+        subprocess.run(["pip", "-V"])
 
     script_ext = "bat" if platform.system() == "Windows" else "sh"
     do_start_options_write = False
@@ -248,8 +251,13 @@ if __name__ == "__main__":
 
         # pip install .[features]
         print(f"Running install command: {' '.join(install_command)}")
-        run_pip(install_command)
-        print()
+
+        try:
+            run_pip(install_command)
+            print()
+        except subprocess.CalledProcessError:
+            print("\nDependency installation failed. Please check the logs and run again.\n")
+            sys.exit(1)
 
         if first_run:
             start_options["first_run_done"] = True


### PR DESCRIPTION
### Summary

The current start.py does not verify the exit status of the dependency installation process. If installing fails (e.g., due to pip errors like _rich_progress_bar crashes as seen in #416), the script still sets first_run_done = True in start_options.json.

This leads to a state where the installation is marked as 'done' despite missing core dependencies. As a result, the script encounters a ModuleNotFoundError during the final init_argparser import.

Additionally, using run_pip for version logging causes uv to return an "unexpected argument '-V'" error due to its different command structure.

### Reproduction

**1. ModuleNotFoundError due to missing verification**
(1) Run start.bat on a fresh install in a way that causes the installation to fail. (Most easy way : disconnect the internet)
(2) The installation fails, but start_options.json is still created with "first_run_done": true.
(3) Re-run start.bat and encounter "Loaded your saved preferences from `start_options.json" and "ModuleNotFoundError: No module named 'pydantic'".

**2. uv version logging error**
Just run tabbyAPI with uv installed, and you can see the "unexpected argument '-V'" error at the start.

### Fixes

- Added check=True to subprocess.run in run_pip.
- Wrapped installation in try-except to set first_run_done = True only on success.
- Added error message and sys.exit(1) on installation failure.
- Fix uv version logging by calling subprocess.run directly.