### PR TITLE
use MTP if model_dir and draft_model_dir are equal

### DIFF
--- a/backends/exllamav3/model.py
+++ b/backends/exllamav3/model.py
@@ -172,7 +172,7 @@ class ExllamaV3Container(BaseModelContainer):
             self.draft_gpu_split = unwrap(draft_args.get("draft_gpu_split"), [])
             self.draft_model_dir = draft_model_path
             self.draft_config = Config.from_directory(str(draft_model_path.resolve()))
-            self.draft_model = Model.from_config(self.draft_config)
+            self.draft_model = Model.from_config(self.draft_config,component=("mtp" if (self.draft_model_dir==self.model_dir) else "text")) #TODO: expose this in a sane way, as a config or something 
             default_ndt = self.draft_model.caps.get("default_draft_size", 4)
             self.draft_num_tokens = draft_args.get("draft_num_tokens", default_ndt)
             xlogger.info(f"Using draft model: {str(draft_model_path.resolve())}")


### PR DESCRIPTION
**Why should this feature be added?**
this seems to be the minimal set of changes needed to make MTP work, on latest exl3 dev branch. 

**Examples**
MTP is enabled if the main model is the same as the draft model. otherwise it behaves normally
..maybe this would more sanely be exposed as a config option?

**Additional context**
tested with <https://huggingface.co/turboderp/Qwen3.6-27B-MTP-exl3> (gotta download the safetensors file and put it in the model dir, i assume it will be included by default in future quants, where supported)
