### PR TITLE
ROCm/gfx1151: allow ExllamaV3 on AMD, skip start.py auto-installer

### DIFF
--- a/backends/exllamav3/model.py
+++ b/backends/exllamav3/model.py
@@ -255,16 +255,24 @@ class ExllamaV3Container(BaseModelContainer):
                 self.autosplit_reserve = [value / 1024 for value in autosplit_reserve_megabytes]
 
         if not hardware_supports_flash_attn(gpu_device_list):
-            gpu_unsupported_message = (
-                "Unable to run ExllamaV3 because an unsupported GPU is "
-                "found in this configuration. \n"
-                "All GPUs must be ampere "
-                "(30 series) or newer. AMD GPUs are not supported."
-            )
+            if torch.version.hip:
+                # ROCm/AMD: exllamav3 runs without flash-attn, falling back to
+                # torch SDPA. Unofficial, but functional on supported builds.
+                xlogger.warning(
+                    "Running ExllamaV3 on ROCm/AMD without flash-attn. "
+                    "This is unofficial and performance may be reduced."
+                )
+            else:
+                gpu_unsupported_message = (
+                    "Unable to run ExllamaV3 because an unsupported GPU is "
+                    "found in this configuration. \n"
+                    "All GPUs must be ampere "
+                    "(30 series) or newer. AMD GPUs are not supported."
+                )
 
-            xlogger.warning(gpu_unsupported_message)
+                xlogger.warning(gpu_unsupported_message)
 
-            raise RuntimeError(gpu_unsupported_message)
+                raise RuntimeError(gpu_unsupported_message)
 
         # Determine max_seq_len and cache_size
         max_seq_len_user = kwargs.get("max_seq_len")

--- a/start.sh
+++ b/start.sh
@@ -2,35 +2,35 @@
 
 cd "$(dirname "$0")" || exit
 
-if command -v uv >/dev/null 2>&1; then
-    HAS_UV=1
-else
-    HAS_UV=0
-fi
+# NOTE: This deployment uses a hand-managed uv environment: a custom ROCm nightly
+# torch built for this AMD GPU (gfx1151) plus an editable, local exllamav3. The
+# stock start.py auto-runs `uv pip install .[amd]` on first launch, which would
+# clobber that torch stack and replace the local exllamav3 with a release wheel.
+# So we activate the existing venv and launch main.py directly, leaving all
+# dependency management to the manual uv setup.
 
 if [ -n "$CONDA_PREFIX" ]; then
     echo "It looks like you're in a conda environment. Skipping venv check."
-else
-    if [ ! -d "venv" ]; then
-        echo "Venv doesn't exist! Creating one for you."
-
-        if [ "$HAS_UV" -eq 1 ]; then
-            echo "It looks like you're using uv. Running appropriate commands."
-            uv venv venv -p 3.12
-        else
-            python3 -m venv venv
-        fi
-
-        if [ -f "start_options.json" ]; then
-            echo "Removing old start_options.json"
-            rm -rf start_options.json
-        fi
-    fi
-
+elif [ -d "venv" ]; then
     echo "Activating venv"
-
     # shellcheck source=/dev/null
     source venv/bin/activate
+else
+    echo "ERROR: venv not found."
+    echo "This deployment relies on a manually-built ROCm environment rather than"
+    echo "start.py's auto-installer (which would install an incompatible torch and"
+    echo "overwrite the local exllamav3). Create the environment first, e.g.:"
+    echo "  uv venv venv -p 3.12"
+    echo "  uv pip install --extra-index-url https://rocm.nightlies.amd.com/v2/gfx1151/ torch triton"
+    echo "  uv pip install -e ."
+    echo "  EXLLAMA_NOCOMPILE=1 uv pip install -e ../exllamav3 --no-deps --no-build-isolation"
+    exit 1
 fi
 
-python3 start.py "$@"
+# Create a default config on first run (mirrors the old start.py behaviour)
+if [ ! -f "config.yml" ]; then
+    echo "config.yml not found; creating one from config_sample.yml"
+    cp config_sample.yml config.yml
+fi
+
+python3 main.py "$@"


### PR DESCRIPTION
backends/exllamav3/model.py: on ROCm/AMD, exllamav3 runs without flash-attn (torch SDPA fallback) rather than hard-failing. Warn and continue instead of raising when hardware_supports_flash_attn() is False but torch.version.hip is set; keep the original error for unsupported NVIDIA configs.

start.sh: activate the existing venv and launch main.py directly instead of running start.py's auto-installer, which would reinstall torch/exllamav3 from the pyproject extras and clobber the hand-built ROCm nightly stack.

**Is your pull request related to a problem? Please describe.**
A clear and concise description of what the problem is. You can also link to an existing issue.

**Why should this feature be added?**
An explanation of why the feature should be added. Please be as specific as possible to help us understand the reasoning.

**Examples**
Examples of the feature in action and its significance compared to not having the feature.

**Additional context**
Add any other context or screenshots about the pull request here.
