### PR TITLE
Add continue_final_message to chat completions

### DIFF
--- a/endpoints/OAI/types/chat_completion.py
+++ b/endpoints/OAI/types/chat_completion.py
@@ -74,6 +74,8 @@ class ChatCompletionRequest(CommonCompletionRequest):
         description="Aliases: chat_template_kwargs",
     )
     response_prefix: Optional[str] = None
+
+    continue_final_message: Optional[bool] = False
     model: Optional[str] = None
 
     # tools is follows the format OAI schema, functions is more flexible

--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -362,9 +362,10 @@ async def apply_chat_template(data: ChatCompletionRequest):
         if continued_message_text is not None:
             prompt = _cut_prompt_at_continue_tag(prompt, continued_message_text)
 
-        # Append response prefix if present
+        # Append response prefix if present. With continue_final_message it
+        # extends the continued turn.
         if data.response_prefix:
-            if data.add_generation_prompt:
+            if data.add_generation_prompt or data.continue_final_message:
                 prompt += data.response_prefix
             else:
                 xlogger.warning(

--- a/endpoints/OAI/utils/chat_completion.py
+++ b/endpoints/OAI/utils/chat_completion.py
@@ -23,6 +23,7 @@ from common.utils import unwrap
 from endpoints.OAI.types.chat_completion import (
     ChatCompletionLogprobs,
     ChatCompletionMessage,
+    ChatCompletionMessagePart,
     ChatCompletionRequest,
     ChatCompletionRespChoice,
     ChatCompletionResponse,
@@ -251,6 +252,85 @@ async def format_messages_with_template(
     return prompt, mm_embeddings, template_vars
 
 
+# The tag mechanism and cut logic are ported from render_jinja_template in
+# huggingface/transformers (src/transformers/utils/chat_template_utils.py,
+# Apache License 2.0). The trailing space is part of the tag.
+# _cut_prompt_at_continue_tag uses its survival through rendering to detect
+# templates that trim trailing whitespace from message content.
+CONTINUE_FINAL_MESSAGE_TAG = "CONTINUE_FINAL_MESSAGE_TAG "
+
+
+def _mark_continued_final_message(data: ChatCompletionRequest) -> str:
+    """Validate a continue_final_message request and append the sentinel tag.
+
+    Replaces the final message with a copy whose text ends in the sentinel
+    tag, so the rendered prompt can be cut back to an unterminated assistant
+    turn. Returns the final message text as it was before the tag.
+    """
+
+    def request_error(message: str) -> HTTPException:
+        error_message = handle_request_error(message).error.message
+        return HTTPException(422, error_message)
+
+    if data.add_generation_prompt:
+        raise request_error("continue_final_message requires add_generation_prompt to be false")
+
+    if not data.messages:
+        raise request_error("continue_final_message is set but there are no messages to continue")
+
+    final_message = data.messages[-1].model_copy(deep=True)
+
+    if isinstance(final_message.content, str):
+        final_text = final_message.content
+        final_message.content = final_message.content + CONTINUE_FINAL_MESSAGE_TAG
+    elif isinstance(final_message.content, list):
+        for part in reversed(final_message.content):
+            if part.type == "text" and part.text is not None:
+                final_text = part.text
+                break
+        else:
+            raise request_error(
+                "continue_final_message is set but the final message has "
+                "no text content to continue"
+            )
+        # A separate final part keeps the tag after any trailing image part.
+        final_message.content = final_message.content + [
+            ChatCompletionMessagePart(type="text", text=CONTINUE_FINAL_MESSAGE_TAG)
+        ]
+    else:
+        raise request_error(
+            "continue_final_message is set but the final message has no content to continue"
+        )
+
+    data.messages = data.messages[:-1] + [final_message]
+    return final_text
+
+
+def _cut_prompt_at_continue_tag(prompt: str, final_message_text: str) -> str:
+    """Cut the rendered prompt back to the end of the continued message."""
+
+    bare_tag = CONTINUE_FINAL_MESSAGE_TAG.strip()
+
+    if final_message_text.strip() not in prompt or bare_tag not in prompt:
+        error_message = handle_request_error(
+            "continue_final_message is set but the final message does not "
+            "appear in the rendered prompt. The prompt template may rewrite "
+            "or drop the final message."
+        ).error.message
+        raise HTTPException(422, error_message)
+
+    tag_loc = prompt.rindex(bare_tag)
+
+    if prompt[tag_loc : tag_loc + len(CONTINUE_FINAL_MESSAGE_TAG)] == CONTINUE_FINAL_MESSAGE_TAG:
+        # The template preserves trailing whitespace in message content.
+        return prompt[:tag_loc]
+
+    # The template trims trailing whitespace from message content. Trim the
+    # continued message the same way so the prompt matches what the template
+    # would have produced for that content by itself.
+    return prompt[:tag_loc].rstrip()
+
+
 async def apply_chat_template(data: ChatCompletionRequest):
     """
     Compile the prompt and get any additional stop strings from the template.
@@ -271,9 +351,16 @@ async def apply_chat_template(data: ChatCompletionRequest):
         if model.container.force_enable_thinking:
             data.template_vars.update({"enable_thinking": True})
 
+        continued_message_text = None
+        if data.continue_final_message:
+            continued_message_text = _mark_continued_final_message(data)
+
         prompt, mm_embeddings, template_vars = await format_messages_with_template(
             data.messages, data.template_vars
         )
+
+        if continued_message_text is not None:
+            prompt = _cut_prompt_at_continue_tag(prompt, continued_message_text)
 
         # Append response prefix if present
         if data.response_prefix:


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
Yes. There is currently no way to continue a partial assistant message through the chat template. The only mechanism for steering the start of a response is `response_prefix`, which appends raw text to the rendered prompt after the generation prompt. Because that text never passes through the template, everything the template does to assistant content is skipped. That includes the spacing it places before a reply, any trimming it applies to the text, and the reasoning tags some templates insert around a turn (e.g. the reasoning tags in DeepSeek-R1).

For example the Mistral large 2411 [prompt](https://huggingface.co/turboderp/Mistral-Large-Instruct-2411-exl3/blob/4.0bpw/tokenizer_config.json#L6177) renders an assistant turn as `" " + content + eos_token`. The space belongs to the template, and the model emits it inside its first token. Suppose the model answered `The story begins` and a client wants to continue that reply. The prompt the model was trained on looks like this:

```
[INST] Tell me a story.[/INST] The story begins
```

With `response_prefix` the client has to reproduce the template's spacing itself. If it sends the text as stored it produces `[/INST]The story begins` with the space missing. If it sends the streamed text verbatim, which starts with the space the model emitted, the prompt becomes `[/INST]  The story begins` with a doubled space, which tokenizes into a sequence the model never saw in training. Getting this right requires the client to know how each model's template spaces its turns.

HF transformers and vLLM both solve this with a `continue_final_message` request option. When set, the final message of the conversation is rendered through the template as a normal turn, and the prompt is then cut back so the turn is left unterminated, with no EOS token and no trailing formatting. Generation continues the message in place. This PR adds the same option to `/v1/chat/completions`, matching their api shape.

The implementation appends a sentinel string to the final message content before rendering, renders normally, and cuts the prompt at the sentinel. The sentinel mechanism and cut logic are ported from `render_jinja_template` in huggingface/transformers ([`src/transformers/utils/chat_template_utils.py`](https://github.com/huggingface/transformers/blob/main/src/transformers/utils/chat_template_utils.py#L539), Apache License 2.0), and the port is credited in a code comment at the sentinel constant. The sentinel carries a trailing space so the cut can detect templates that trim trailing whitespace from message content (for example `content | trim`) and trim the continued text the same way. If the template rewrites or drops the final message so the sentinel does not survive rendering, the request fails with a 422 rather than guessing a cut point. `add_generation_prompt` must be false when `continue_final_message` is set, matching vLLM, otherwise the request fails with a 422.

Because HF and vLLM do not have our existing `response_prefix` parameter, I had to define how `response_prefix` interacts with `continue_final_message`. I chose to allow the use of both simultaneously. When both are used `response_prefix` is appended verbatim after the continued turn. Existing use of `response_prefix` is unchanged.

This PR has an intentional difference from the transformers implementation.

In this implementation the sentinel is appended as its own final content part rather than into the last text part. `format_messages_with_template` flattens parts into one string in list order, so the rendered prompt is unchanged for text content, and an image part that follows the last text part stays ahead of the cut instead of being deleted with it. The transformers implementation appends into the last text block and loses a trailing image on continuation.

Finally, there is a known limitation which is that tool calls on the final message are lost, since templates render them after the content and the cut removes them. This limitation is also present in the transformers and vLLM implementations.

**Why should this feature be added?**
It brings the chat endpoint to parity with HF transformers and vLLM for continuing assistant messages, and it removes the need for clients to carry per-model template knowledge to build correct continuations. The change is contained to the chat completion request type and `apply_chat_template`. Requests that do not set the option render the same prompts as before.

**Examples**
Request against mistral large 2411 :

```
POST /v1/chat/completions
{
  "messages": [
    {"role": "user", "content": "Tell me a story."},
    {"role": "assistant", "content": "The story begins"}
  ],
  "continue_final_message": true,
  "add_generation_prompt": false,
  "max_tokens": 64
}
```

The rendered prompt ends with:

```
[INST] Tell me a story.[/INST] The story begins
```

The template's own space after `[/INST]` is present, there is no EOS token, and the model continues the sentence. 
