### PR TITLE
Add ability to ban tokens on exl3 backend

### DIFF
--- a/backends/exllamav3/model.py
+++ b/backends/exllamav3/model.py
@@ -1089,6 +1089,12 @@ class ExllamaV3Container(BaseModelContainer):
         if params.adaptive_target < 1.0:
             sampler_builder.adaptive_p(params.adaptive_target, params.adaptive_decay)
 
+        # Fetch EOS tokens from generation_config if they exist
+        eos_tokens = self.hf_model.eos_tokens() or [self.tokenizer.eos_token_id]
+
+        if params.ban_eos_token:
+            sampler_builder.ban_tokens(eos_tokens + self.config.eos_token_id_list)
+
         # Build the sampler
         # Set greedy if temperature is 0
         sampler = sampler_builder.build(params.temperature == 0)
@@ -1110,14 +1116,13 @@ class ExllamaV3Container(BaseModelContainer):
         # Get multimodal embeddings if present
         mm_embeddings_content = mm_embeddings.content if mm_embeddings else []
 
-        # Fetch EOS tokens from generation_config if they exist
-        eos_tokens = self.hf_model.eos_tokens() or [self.tokenizer.eos_token_id]
+        # Treat EOS tokens as stop conditions unless the request bans them
+        if not params.ban_eos_token:
+            stop_conditions += eos_tokens
 
-        stop_conditions += eos_tokens
-
-        # Include stop conditions deduced by backend tokenizer
-        stop_conditions += self.config.eos_token_id_list
-        stop_conditions = list(set(stop_conditions))
+            # Include stop conditions deduced by backend tokenizer
+            stop_conditions += self.config.eos_token_id_list
+            stop_conditions = list(set(stop_conditions))
 
         input_ids = [
             self.tokenizer.encode(

--- a/backends/exllamav3/model.py
+++ b/backends/exllamav3/model.py
@@ -1092,8 +1092,12 @@ class ExllamaV3Container(BaseModelContainer):
         # Fetch EOS tokens from generation_config if they exist
         eos_tokens = self.hf_model.eos_tokens() or [self.tokenizer.eos_token_id]
 
+        banned_tokens = list(params.banned_tokens or [])
         if params.ban_eos_token:
-            sampler_builder.ban_tokens(eos_tokens + self.config.eos_token_id_list)
+            banned_tokens += eos_tokens + self.config.eos_token_id_list
+
+        if banned_tokens:
+            sampler_builder.ban_tokens(banned_tokens)
 
         # Build the sampler
         # Set greedy if temperature is 0

--- a/backends/exllamav3/sampler.py
+++ b/backends/exllamav3/sampler.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass, field
 from typing import List
+import torch
 from exllamav3.generator.sampler import (
     CustomSampler,
     SS_Temperature,
@@ -13,6 +14,25 @@ from exllamav3.generator.sampler import (
     SS_Base,
     SS_AdaptiveP,
 )
+from exllamav3.generator.sampler.custom import SS
+
+
+class SS_BanTokens(SS_Base):
+    """Sampling step that masks the given token IDs to negative infinity."""
+
+    def __init__(self, token_ids):
+        self.token_ids = list(token_ids)
+
+    def run(self, state):
+        match state.state:
+            case SS.INIT:
+                state.logits = state.in_logits.to(torch.float, copy=True)
+                state.logits[:, self.token_ids] = float("-inf")
+            case SS.LOGITS:
+                state.logits[:, self.token_ids] = float("-inf")
+            case _:
+                raise ValueError("Sampling logic error")
+        state.state = SS.LOGITS
 
 
 @dataclass
@@ -22,6 +42,7 @@ class ExllamaV3SamplerBuilder:
     """
 
     stack: List[SS_Base] = field(default_factory=list)
+    banned_tokens: List[int] = field(default_factory=list)
 
     def penalties(self, rep_p, freq_p, pres_p, penalty_range, rep_decay):
         self.stack += [
@@ -47,16 +68,23 @@ class ExllamaV3SamplerBuilder:
     def adaptive_p(self, adaptive_target, adaptive_decay):
         self.stack.append(SS_AdaptiveP(adaptive_target, adaptive_decay))
 
+    def ban_tokens(self, token_ids):
+        self.banned_tokens = list(token_ids)
+
     def build(self, greedy):
         """Builds the final sampler from stack."""
 
+        # A ban step runs first so masked tokens stay out of every later step,
+        # including the greedy path that otherwise discards the stack.
+        prefix = [SS_BanTokens(self.banned_tokens)] if self.banned_tokens else []
+
         # Adaptive-P does categorical sampling already
         if len(self.stack) and isinstance(self.stack[-1], SS_AdaptiveP):
-            return CustomSampler(self.stack)
+            return CustomSampler(prefix + self.stack)
 
         # Use greedy if temp is 0
         if greedy:
-            return CustomSampler([SS_Argmax()])
+            return CustomSampler(prefix + [SS_Argmax()])
         else:
             self.stack.append(SS_Sample())
-            return CustomSampler(self.stack)
+            return CustomSampler(prefix + self.stack)


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
TabbyAPI exposes the fields `ban_eos_token` and  `banned_tokens` which can be used to allow for generation to continue indefinitely or to ban certain desired tokens. However this feature does nothing when using the exl3 backend. This PR resolves this.

**Why should this feature be added?**
These fields are present (or have equivalent features) across OAI compatible implementations (e.g. [textgen](https://github.com/oobabooga/textgen)). It also is present in TabbyAPI's own exl2 implementation. 