### PR TITLE
fix(model): recognize symlink aliases as the loaded model during inline loading

### DIFF
--- a/common/model.py
+++ b/common/model.py
@@ -145,7 +145,12 @@ async def load_model_gen(model_path: pathlib.Path, **kwargs):
         if container and container.model:
             loaded_model_name = container.model_dir.name
 
-            if loaded_model_name == model_path.name and container.loaded:
+            # Compare resolved paths, not just directory names, so a symlink
+            # alias pointing at the already-loaded model is recognized as the
+            # same model instead of triggering a spurious unload/reload (#379).
+            already_loaded = container.model_dir.resolve() == model_path.resolve()
+
+            if already_loaded and container.loaded:
                 xlogger.info(f'Model "{loaded_model_name}" is already loaded')
 
                 # Emit a terminal progress event so API clients always

--- a/endpoints/OAI/utils/common_.py
+++ b/endpoints/OAI/utils/common_.py
@@ -62,9 +62,13 @@ def aggregate_usage_stats(usage_stats_list: list[UsageStats]) -> UsageStats:
 async def load_inline_model(model_name: str, request: Request):
     """Load a model from the data.model parameter"""
 
-    # Return if the model container already exists and the model is fully loaded
-    if model.container and model.container.model_dir.name == model_name and model.container.loaded:
-        return
+    # Return if the model container already exists and the model is fully loaded.
+    # Compare resolved paths so a symlink alias for the loaded model is treated
+    # as already loaded instead of triggering a spurious reload (#379).
+    if model.container and model.container.loaded:
+        requested_dir = pathlib.Path(config.model.model_dir) / model_name
+        if model.container.model_dir.resolve() == requested_dir.resolve():
+            return
 
     # Return if inline loading is disabled
     # Also warn if an admin key is used


### PR DESCRIPTION
### Problem

Fixes #379.

With `inline_model_loading: true`, a model can be addressed by directory name in the request's `model` field. If that name is a **symlink** to the real model directory (the issue's example: a `coder` symlink pointing at `ArtusDev_Qwen_Qwen3-Coder-30B-A3B-Instruct-EXL3`), the model is unloaded and reloaded on *every* request even though it is already loaded.

### Cause

The "is this already loaded?" check compares the requested name against `container.model_dir.name`:

```python
loaded_model_name = container.model_dir.name
if loaded_model_name == model_path.name and container.loaded:
    ...  # already loaded, skip
```

But the container is created from `model_path.resolve()` (`common/model.py`), so `model_dir.name` is always the **real** directory name. A symlink alias (`coder`) never equals the resolved name (`ArtusDev_...-EXL3`), so the guard fails and the model is reloaded. The same bare-name comparison sits in the inline fast-path guard in `endpoints/OAI/utils/common_.py`.

### Fix

Compare **resolved paths** instead of bare directory names in both places, so a symlink that points at the currently-loaded model is recognized as the same model. Non-symlink paths resolve to themselves, so existing behavior is unchanged.

- `common/model.py` — `load_model_gen`: `container.model_dir.resolve() == model_path.resolve()`
- `endpoints/OAI/utils/common_.py` — `load_inline_model`: resolve the requested `model_dir / model_name` and compare against the loaded container's resolved dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
