### PR TITLE
Ignore HF's generation tags in jinja templates

### DIFF
--- a/common/templating.py
+++ b/common/templating.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from importlib.metadata import version as package_version
 from typing import Optional
 from jinja2 import Template, TemplateError
-from jinja2.ext import loopcontrols
+from jinja2.ext import loopcontrols, Extension
 from jinja2.sandbox import ImmutableSandboxedEnvironment
 from common.logger import xlogger
 from markupsafe import Markup
@@ -16,6 +16,16 @@ from packaging import version
 
 
 from common.utils import unwrap
+
+
+class IgnoreGenerationTags(Extension):
+    """Pass-through for HuggingFace's ``{% generation %}`` chat-template tag."""
+
+    tags = {"generation"}
+
+    def parse(self, parser):
+        parser.stream.skip(1)
+        return parser.parse_statements(("name:endgeneration",), drop_needle=True)
 
 
 class TemplateLoadError(Exception):
@@ -63,7 +73,7 @@ def _create_environment() -> ImmutableSandboxedEnvironment:
         trim_blocks=True,
         lstrip_blocks=True,
         enable_async=True,
-        extensions=[loopcontrols],
+        extensions=[IgnoreGenerationTags, loopcontrols],
     )
     environment.globals["strftime_now"] = _strftime_now
     environment.globals["raise_exception"] = _raise_exception


### PR DESCRIPTION
This allows to load e.g. [Laguna-XS-2.1](https://huggingface.co/turboderp/Laguna-XS-2.1-exl3), otherwise it will give an error:

```
jinja2.exceptions.TemplateSyntaxError: Encountered unknown tag 'generation'. Jinja was looking for the following tags: 'elif' or 'else' or 'endif'. The innermost block that needs to be closed is 'if'.
```

and chat completion won't work.

`IgnoreGenerationTags` extension is taken from [llama-cpp-python](https://github.com/abetlen/llama-cpp-python/blob/629bd1b333f60d24a01886c5f99019f4c7c3ea6c/llama_cpp/llama_chat_format.py#L196-L203).