### PR TITLE
docs: correct `--gpu-split-auto` CLI flag in server options

### DIFF
--- a/docs/02.-Server-options.md
+++ b/docs/02.-Server-options.md
@@ -6,7 +6,7 @@
 TabbyAPI primarily uses a config.yml file to adjust various options. This is the preferred way and has the ability to adjust all options of TabbyAPI.
 
 CLI arguments are also included, but those serve to *override* the options set in config.yml. Therefore, they act a bit differently compared to other programs, especially with booleans.
-Example: A user sets `gpu_split_auto` to True. The CLI arg will then be `--gpu_split-auto False` to override that previous config.yml setting.
+Example: A user sets `gpu_split_auto` to True. The CLI arg will then be `--gpu-split-auto False` to override that previous config.yml setting.
 
 In addition, some config.yml options are too complex to represent as command args, so those are not included with the argparser.
 


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
`docs/02.-Server-options.md` (line 9) documents the boolean-override example with the flag `--gpu_split-auto`:

> Example: A user sets `gpu_split_auto` to True. The CLI arg will then be `--gpu_split-auto False` to override that previous config.yml setting.

That flag string does not exist. `common/args.py` builds every CLI flag from the config field name by replacing underscores with hyphens:

```python
sub_field_name = sub_field_name.replace("_", "-")   # common/args.py
```

So the `gpu_split_auto` field is exposed as `--gpu-split-auto`, not `--gpu_split-auto`. A user copy-pasting the documented example hits:

```
error: unrecognized arguments: --gpu_split-auto False
```

**Why should this feature be added?**
This is a one-word docs fix. The example is meant to teach the boolean-override behavior, but as written it fails verbatim, which is confusing precisely for the users who follow the docs. The config **key** `gpu_split_auto` (used in `config.yml`) is correct and unchanged — only the CLI arg string is fixed.

**Examples**
- Before (documented): `--gpu_split-auto False` → `unrecognized arguments`
- After (fixed): `--gpu-split-auto False` → parses correctly

**Additional context**
Docs-only, single line, no code change.