### PR TITLE
fix(formatting): read ruff pin from pyproject.toml, not missing requirements-dev.txt

### DIFF
--- a/formatting.sh
+++ b/formatting.sh
@@ -31,7 +31,7 @@ tool_version_check() {
     fi
 }
 
-tool_version_check "ruff" $RUFF_VERSION "$(grep "ruff==" requirements-dev.txt | cut -d'=' -f3)"
+tool_version_check "ruff" $RUFF_VERSION "$(grep -oE 'ruff *== *[0-9.]+' pyproject.toml | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')"
 
 # Format and lint all files
 format_and_lint() {


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**
`formatting.sh` aborts before it formats anything, for every contributor who runs it. Line 34 checks the required ruff version by grepping `requirements-dev.txt`:

```sh
tool_version_check "ruff" $RUFF_VERSION "$(grep "ruff==" requirements-dev.txt | cut -d'=' -f3)"
```

But `requirements-dev.txt` does not exist in the repo — dev dependencies live in `pyproject.toml`:

```toml
[project.optional-dependencies]
dev = [
    "ruff == 0.11.10"
]
```

Since the script runs under `set -eo pipefail`, the failed `grep` makes the required-version substring empty, so `tool_version_check` sees a mismatch and does `exit 1`:

```
Wrong ruff version installed:  is required, not 0.11.10.
```

**Why should this feature be added?**
The dev formatting helper is currently unusable. This repoints the version check at the real source of truth (`pyproject.toml`) and tolerates its spaced `ruff == x.y.z` pin (the old `cut -d=` logic assumed the unspaced `ruff==` form). One-line change.

**Examples**
- Before: `bash formatting.sh` → `grep: requirements-dev.txt: No such file or directory` → `Wrong ruff version installed:  is required, not 0.11.10.` → exit 1.
- After (ruff 0.11.10 installed): version check passes, `ruff format` / `ruff check` run.

**Additional context**
Verified locally under `set -eo pipefail`: the new extraction yields exactly `0.11.10` from `pyproject.toml`, matches a correct install, and still flags a wrong one. `bash -n` clean.