### PR TITLE
Update sampling.py

### DIFF
--- a/common/sampling.py
+++ b/common/sampling.py
@@ -24,7 +24,6 @@ from common.utils import filter_none_values, unwrap
 # Requests that activate any of these get a warning and the param is ignored.
 UNSUPPORTED_PARAMS = {
     "ban_eos_token": False,
-    "banned_tokens": [],
     "allowed_tokens": [],
     "smoothing_factor": 0.0,
     "top_a": 0.0,

--- a/common/sampling.py
+++ b/common/sampling.py
@@ -31,7 +31,6 @@ UNSUPPORTED_PARAMS = {
     "tfs": 1.0,
     "typical": 1.0,
     "skew": 0.0,
-    "xtc_probability": 0.0,
     "dry_multiplier": 0.0,
     "mirostat_mode": 0,
     "logit_bias": None,


### PR DESCRIPTION
Deleted xtc_probability from unsupported_params, because it was added in exllamav3 v1.3.0.