### PR TITLE
Sampling: Support logit_bias on the exllamav3 backend

### DIFF
--- a/backends/exllamav3/model.py
+++ b/backends/exllamav3/model.py
@@ -1136,6 +1136,10 @@ class ExllamaV3Container:
 
         sampler_builder = ExllamaV3SamplerBuilder()
 
+        # Apply logit bias first so it lands ahead of the other steps
+        if params.logit_bias:
+            sampler_builder.logit_bias(params.logit_bias)
+
         # Penalties
 
         # Set penalty range

--- a/backends/exllamav3/sampler.py
+++ b/backends/exllamav3/sampler.py
@@ -12,6 +12,7 @@ from exllamav3.generator.sampler import (
     SS_Sample,
     SS_Base,
     SS_AdaptiveP,
+    SS_LogitBias,
 )
 
 
@@ -40,6 +41,10 @@ class ExllamaV3SamplerBuilder:
 
     def min_p(self, min_p):
         self.stack.append(SS_MinP(min_p))
+
+    def logit_bias(self, logit_bias):
+        # Must run before the logits are transformed, so prepend it to the stack
+        self.stack.insert(0, SS_LogitBias(logit_bias))
 
     def greedy(self):
         self.stack.append(SS_Argmax())

--- a/common/sampling.py
+++ b/common/sampling.py
@@ -34,7 +34,6 @@ UNSUPPORTED_PARAMS = {
     "xtc_probability": 0.0,
     "dry_multiplier": 0.0,
     "mirostat_mode": 0,
-    "logit_bias": None,
     "temp_exponent": 1.0,
 }
 


### PR DESCRIPTION
Passes `logit_bias` through to the exllamav3 backend, so requests that set it are honored instead of dropped with a warning (turboderp-org/exllamav3#270).

Three changes: drop `logit_bias` from `UNSUPPORTED_PARAMS`; add a `logit_bias()` method to `ExllamaV3SamplerBuilder` that prepends `SS_LogitBias` (it must run before the logits are transformed); and call it from the exllamav3 model when a request sets a bias.

**Depends on** turboderp-org/exllamav3#274, which adds `SS_LogitBias` — this won't import until that PR lands or an exllamav3 release includes it, so opening as a draft.
