### PR TITLE
fix(deps): point the cu13 extra at ExLlamaV3 v1.3.0 wheels (#446)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,12 +102,12 @@ cu13 = [
     "flash-linear-attention >= 0.5.0 ; python_version >= '3.12' and ((platform_system == 'Linux' and platform_machine == 'x86_64') or platform_system == 'Windows')",
 
     # Exl3
-    "exllamav3 @ https://github.com/turboderp-org/exllamav3/releases/download/v1.1.0/exllamav3-1.1.0%2Bcu132.torch2.11.0-cp314-cp314-win_amd64.whl ; platform_system == 'Windows' and python_version == '3.14'",
-    "exllamav3 @ https://github.com/turboderp-org/exllamav3/releases/download/v1.1.0/exllamav3-1.1.0%2Bcu132.torch2.11.0-cp313-cp313-win_amd64.whl ; platform_system == 'Windows' and python_version == '3.13'",
-    "exllamav3 @ https://github.com/turboderp-org/exllamav3/releases/download/v1.1.0/exllamav3-1.1.0%2Bcu132.torch2.11.0-cp312-cp312-win_amd64.whl ; platform_system == 'Windows' and python_version == '3.12'",
-    "exllamav3 @ https://github.com/turboderp-org/exllamav3/releases/download/v1.1.0/exllamav3-1.1.0%2Bcu132.torch2.11.0-cp314-cp314-linux_x86_64.whl ; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version == '3.14'",
-    "exllamav3 @ https://github.com/turboderp-org/exllamav3/releases/download/v1.1.0/exllamav3-1.1.0%2Bcu132.torch2.11.0-cp313-cp313-linux_x86_64.whl ; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version == '3.13'",
-    "exllamav3 @ https://github.com/turboderp-org/exllamav3/releases/download/v1.1.0/exllamav3-1.1.0%2Bcu132.torch2.11.0-cp312-cp312-linux_x86_64.whl ; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version == '3.12'",
+    "exllamav3 @ https://github.com/turboderp-org/exllamav3/releases/download/v1.3.0/exllamav3-1.3.0%2Bcu132.torch2.11.0-cp314-cp314-win_amd64.whl ; platform_system == 'Windows' and python_version == '3.14'",
+    "exllamav3 @ https://github.com/turboderp-org/exllamav3/releases/download/v1.3.0/exllamav3-1.3.0%2Bcu132.torch2.11.0-cp313-cp313-win_amd64.whl ; platform_system == 'Windows' and python_version == '3.13'",
+    "exllamav3 @ https://github.com/turboderp-org/exllamav3/releases/download/v1.3.0/exllamav3-1.3.0%2Bcu132.torch2.11.0-cp312-cp312-win_amd64.whl ; platform_system == 'Windows' and python_version == '3.12'",
+    "exllamav3 @ https://github.com/turboderp-org/exllamav3/releases/download/v1.3.0/exllamav3-1.3.0%2Bcu132.torch2.11.0-cp314-cp314-linux_x86_64.whl ; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version == '3.14'",
+    "exllamav3 @ https://github.com/turboderp-org/exllamav3/releases/download/v1.3.0/exllamav3-1.3.0%2Bcu132.torch2.11.0-cp313-cp313-linux_x86_64.whl ; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version == '3.13'",
+    "exllamav3 @ https://github.com/turboderp-org/exllamav3/releases/download/v1.3.0/exllamav3-1.3.0%2Bcu132.torch2.11.0-cp312-cp312-linux_x86_64.whl ; platform_system == 'Linux' and platform_machine == 'x86_64' and python_version == '3.12'",
 ]
 # MARK: Ruff options
 


### PR DESCRIPTION
Fixes #446.

### Problem

The `cu13` extra still resolves the ExLlamaV3 wheels from the **v1.1.0** release:

```
exllamav3 @ .../releases/download/v1.1.0/exllamav3-1.1.0%2Bcu132.torch2.11.0-cp313-cp313-linux_x86_64.whl
```

so `pip install -U .[cu13]` installs ExLlamaV3 1.1.0, while the `cu12` extra
right above it already installs **1.3.0**. CUDA 13 users have to replace the
wheel by hand after every install to get the current release.

### Fix

Bump the six `cu13` wheel URLs from `v1.1.0` to `v1.3.0`. Nothing else changes —
the diff is 6 lines in one file, tag and filename only.

### Why this is safe

- **The wheels exist.** The `v1.3.0` release publishes exactly the six
  `cu132.torch2.11.0` variants the `cu13` extra references —
  `cp312`/`cp313`/`cp314` × `win_amd64`/`linux_x86_64` — the same matrix
  `v1.1.0` published. No marker in the extra is left without a wheel.
- **The build is `cu132.torch2.11.0` in both releases**, matching the
  `torch 2.11.0+cu130` pins in the same extra. The ABI target is unchanged.
- **1.3.0 is already exercised by this repo.** The `cu12` extra has been on
  `exllamav3` 1.3.0 since it was released (2026-07-31), so the backend code in
  `backends/exllamav3/` is already running against that version on CUDA 12.
  This only brings CUDA 13 to parity.
- `docker/Dockerfile.cu13` installs via `.[cu13]`, so it picks the bump up with
  no change of its own.

Credit to @Mario5Gray for reporting and for pinpointing it to the extra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
