### PR TITLE
fix(server): make CORS origins configurable and drop the credentialed wildcard (#448)

### DIFF
--- a/common/config_models.py
+++ b/common/config_models.py
@@ -53,6 +53,18 @@ class NetworkConfig(BaseConfigModel):
             "Turn on this option if you are ONLY connecting from localhost."
         ),
     )
+    allowed_origins: Optional[List[str]] = Field(
+        ["*"],
+        description=(
+            'Origins allowed to call the API from a browser (default: ["*"]).\n'
+            "This is a CORS allowlist, not an auth mechanism: it only governs which\n"
+            "web pages a browser will let read this API's responses.\n"
+            'The default "*" means any site open in your browser can send requests to\n'
+            "this instance, which matters most when disable_auth is on. Restrict this to\n"
+            'your own frontends (e.g. ["http://localhost:8000"]) to close that off, or\n'
+            "use an empty list [] to block all browser (cross-origin) callers."
+        ),
+    )
     disable_fetch_requests: Optional[bool] = Field(
         False,
         description=(

--- a/config_sample.yml
+++ b/config_sample.yml
@@ -20,6 +20,13 @@ network:
   # Turn on this option if you are ONLY connecting from localhost.
   disable_auth: false
 
+  # Origins allowed to call the API from a browser (default: ["*"]).
+  # This is a CORS allowlist, not authentication: "*" lets any site open in your
+  # browser send requests to this instance, which matters most when disable_auth
+  # is on. Restrict to your own frontends (e.g. ["http://localhost:8000"]) or use
+  # an empty list [] to block all browser (cross-origin) callers.
+  allowed_origins: ["*"]
+
   # Disable fetching external content in response to requests,such as images from URLs.
   disable_fetch_requests: false
 

--- a/endpoints/server.py
+++ b/endpoints/server.py
@@ -29,11 +29,14 @@ def setup_app(host: Optional[str] = None, port: Optional[int] = None):
     )
     app.add_exception_handler(ContextLengthHTTPException, context_length_exception_handler)
 
-    # ALlow CORS requests
+    # Allow CORS requests from the configured origins.
+    # allow_credentials stays False: TabbyAPI authenticates with a header/query
+    # token rather than cookies, so credentialed CORS buys nothing and would make
+    # Starlette reflect an arbitrary requesting origin back instead of sending "*".
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
-        allow_credentials=True,
+        allow_origins=config.network.allowed_origins,
+        allow_credentials=False,
         allow_methods=["*"],
         allow_headers=["*"],
     )


### PR DESCRIPTION
## Summary

Fixes the CORS portion of #448. TabbyAPI ships:

```python
app.add_middleware(
    CORSMiddleware,
    allow_origins=["*"],
    allow_credentials=True,
    allow_methods=["*"],
    allow_headers=["*"],
)
```

Because `allow_credentials=True` is combined with `allow_origins=["*"]`, Starlette **reflects the requesting origin** (rather than sending a literal `*`). Any web page a user has open in their browser is also "connecting from localhost", so it can pass preflight, POST to `http://127.0.0.1:5000`, and read the responses. For an instance running with `disable_auth: true` — which the config sample explicitly recommends for localhost-only use — that page reaches the admin surface (`/v1/model/load`, `/v1/download`, `/v1/model/list` with the resolved model path, ...). Thanks @elfrost for the detailed write-up and repro.

## Change

- Add a `network.allowed_origins` config key so the CORS allowlist is configurable. **Default is `["*"]`, preserving today's behavior** so existing browser frontends keep working out of the box.
- Set `allow_credentials=False`. TabbyAPI authenticates with a header/query token, never cookies, so credentialed CORS provides nothing and only enables the origin-reflection footgun. With this change the middleware sends a literal `*` (or the configured allowlist) instead of reflecting an arbitrary origin, and operators who want to lock down a shared instance can now set an explicit allowlist or an empty list `[]`.

```yaml
network:
  # Restrict to your own frontends, or [] to block all cross-origin callers.
  allowed_origins: ["http://localhost:8000"]
```

## Note on the default

I kept the default permissive (`["*"]`) to avoid breaking existing browser UIs on upgrade, and scoped this PR to exposing the knob + removing the credentialed-wildcard footgun. If you'd prefer a secure-by-default posture (default `[]`, browser callers opt in), that's a one-line change to the field default — happy to flip it if you want that instead.

The second item in #448 (the `image_url` server-side fetch / SSRF surface) is orthogonal and left for a separate change.

## Testing

`config_sample.yml` is updated to document the new key. The repo's `tests/` are live-server integration scripts (they need a loaded model), so there's no unit harness for middleware wiring to extend here; the change is config-driven and `common/config_models.py` + `endpoints/server.py` compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
