### PR TITLE
fix(docker): install python3.12-dev so Triton can JIT in the container (#453)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,12 +1,17 @@
 # Use an official CUDA runtime with Ubuntu as a parent image
 FROM nvidia/cuda:12.8.1-runtime-ubuntu24.04
 
-# Install system dependencies
+# Install system dependencies. python3.12-dev supplies Python.h, which Triton's
+# runtime JIT needs to build its cuda_utils extension inside the container. The
+# venv resolves its include path to /usr/include/python3.12, so the headers have
+# to come from the system python, not from the venv.
+# See: https://github.com/theroyallab/tabbyAPI/issues/453
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     curl \
     ca-certificates \
     python3.12 \
+    python3.12-dev \
     python3-pip \
     python3.12-venv \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/Dockerfile.cu13
+++ b/docker/Dockerfile.cu13
@@ -1,12 +1,17 @@
 # Use an official CUDA 13 runtime with Ubuntu as a parent image
 FROM nvidia/cuda:13.2.1-runtime-ubuntu24.04
 
-# Install system dependencies
+# Install system dependencies. python3.12-dev supplies Python.h, which Triton's
+# runtime JIT needs to build its cuda_utils extension inside the container. The
+# venv resolves its include path to /usr/include/python3.12, so the headers have
+# to come from the system python, not from the venv.
+# See: https://github.com/theroyallab/tabbyAPI/issues/453
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     curl \
     ca-certificates \
     python3.12 \
+    python3.12-dev \
     python3-pip \
     python3.12-venv \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
**Is your pull request related to a problem? Please describe.**

Fixes #453. Starting the container logs a burst of build failures before the server comes up:

```
/tmp/tmpe68t6sye/cuda_utils.c:6:10: fatal error: Python.h: No such file or directory
    6 | #include <Python.h>
      |          ^~~~~~~~~~
compilation terminated.
/opt/venv/lib/python3.12/site-packages/fla/utils/_device.py:100: UserWarning: Triton is not supported on current platform, roll back to CPU.
```

`triton` is a declared dependency of both the `cu12` and `cu13` groups
(`pyproject.toml` L74-76 / L101-102), so it is always in the image. Triton compiles its
`cuda_utils` extension at runtime, which needs the CPython development headers.

Both Dockerfiles install `python3.12`, `python3-pip` and `python3.12-venv`, but not
`python3.12-dev` — so `Python.h` is not in the image. `build-essential` is already there,
so the headers are the only missing piece.

Putting them in the venv would not help: `sysconfig` reports the interpreter's include
path from the *base* prefix even inside a venv, which is where Triton looks —

```console
$ /opt/venv/bin/python -c "import sysconfig; print(sysconfig.get_paths()['include'])"
/usr/include/python3.12
```

and on Ubuntu 24.04 that path is owned by `python3.12-dev` (via `libpython3.12-dev`):

```console
$ dpkg -S /usr/include/python3.12/Python.h
libpython3.12-dev:amd64: /usr/include/python3.12/Python.h
```

**Why should this feature be added?**

The failure is not only log noise. The compile error is what `flash-linear-attention`'s
Triton probe hits, and it responds by rolling back to CPU — so an image that ships Triton
on purpose silently runs without it.

Both `docker/Dockerfile` and `docker/Dockerfile.cu13` have the identical `apt-get` block
and the identical gap, so both are fixed here.

**Examples**

Before:

```console
$ docker compose -f docker/docker-compose.yml up
tabbyapi-1  | /tmp/tmpe68t6sye/cuda_utils.c:6:10: fatal error: Python.h: No such file or directory
tabbyapi-1  | compilation terminated.
tabbyapi-1  | .../fla/utils/_device.py:100: UserWarning: Triton is not supported on current platform, roll back to CPU.
```

After: `Python.h` resolves, the JIT build succeeds, and the rollback warning is gone.

**Additional context**

One package added per Dockerfile; no change to the venv, the install steps, or the
entrypoint. The added layer is a few MB. The existing `Docker smoke test` workflow builds
both files on any `docker/**` change, so this PR exercises both images.

I do not have a CUDA host to run the image on, so I verified the mechanism rather than the
container: the `sysconfig` include path and the `dpkg -S` ownership above were both checked
on Ubuntu 24.04 with CPython 3.12. Worth a maintainer running the image once to confirm the
warning is gone end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
