### PR TITLE
fix(templating): default tojson ensure_ascii=False to prevent token bloat

### DIFF
--- a/common/templating.py
+++ b/common/templating.py
@@ -39,11 +39,16 @@ def _raise_exception(message):
     raise TemplateError(message)
 
 
-def _tojson_compat(value, indent=None, ensure_ascii=True):
+def _tojson_compat(value, indent=None, ensure_ascii=False):
     """Compatibility JSON filter for chat templates.
 
     Some model templates call ``tojson(ensure_ascii=False)`` while the
     bundled Jinja filter may not accept that keyword in sandboxed mode.
+
+    Defaults to ``ensure_ascii=False`` to match transformers: escaping
+    non-ASCII text (e.g. Chinese tool descriptions) into unicode escape
+    sequences silently bloats token counts several-fold and degrades model
+    comprehension.
 
     Returns a plain string, matching the transformers template environment:
     autoescape is off, and a Markup return value would HTML-escape any plain


### PR DESCRIPTION
## Problem

The chat template `tojson` filter (`_tojson_compat` in `common/templating.py`)
defaulted to `ensure_ascii=True`. When a Qwen3.5-style template renders tool
definitions via `{{- tool | tojson }}`, all non-ASCII characters (e.g. Chinese
tool descriptions) in the tool schemas get escaped to `\uXXXX` sequences.

This has two effects for users with Chinese-language MCP/function tools:

1. **Prompt token bloat:** token counts roughly double. Reproduced with a real
   request: the same input (one user message + 10 tools with Chinese
   descriptions) was ~3300 tokens with descriptions kept as UTF-8 text, but
   5845 tokens after escaping. BPE tokenization of `\uXXXX` escapes is far
   less efficient than the original characters.
2. **Degraded comprehension:** the model sees escaped gibberish instead of
   readable tool descriptions, hurting function-calling behavior.

## Fix

Default `ensure_ascii=False` in `_tojson_compat`, matching the transformers
chat template environment. Callers that explicitly pass `ensure_ascii=True`
still work.

## Verification

- Rendered the same request through both paths:
  - before: 12754 chars / 5835 tokens (escaped)
  - after:  9109 chars / 2993 tokens (UTF-8 text, ~48% reduction)
- `tests/test_template_vars.py` passes (15/15).
