### PR TITLE
Tool calling: add LFM2 / LFM2.5 pythonic tool call parser + chat template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,6 +195,7 @@ templates/*
 !templates/place_your_templates_here.txt
 !templates/alpaca.jinja
 !templates/chatml.jinja
+!templates/lfm2.jinja
 
 # Sampler overrides folder
 sampler_overrides/*

--- a/docs/10.-Tool-Calling.md
+++ b/docs/10.-Tool-Calling.md
@@ -29,7 +29,8 @@ Below are the currently recognized tool call formats. Reasoning tags should be s
 | deepseek_v4 ⁴  | dsv4                                         | `<think>` `</think>`                       | DeepSeek-V4<br> DeepSeek-V4-Flash                                                                                                                                               
 | harmony ²      |                                              |                                            | gpt-oss-20b<br> gpt-oss-120b                                                                                                                                                    
 | hy3 ³          | hy_v3                                        | `<think:opensource>` `</think:opensource>` | Hy3 (Tencent Hunyuan)                                                                                                                                                           
-| muse_glimmer ² | glimmer                                      |                                            | Muse Glimmer                                                                                                                                                                    
+| lfm2 ⁵         | lfm<br> lfm2_5                               |                                            | LFM2 / LFM2.5 (Liquid AI)                                                                                                                                                        
+| muse_glimmer ² | glimmer                                      |                                            | Muse Glimmer
 | mistral_old ¹  |                                              |                                            | (older Mistral-family models)                                                                                                                                                   
 | mistral        |                                              | `[THINK]` `[/THINK]`                       | Codestral 2508+<br> Devstral-Small 2507+<br> Magistral-Medium 2506+<br> Magistral-Small 2506+<br> Ministral-3 2512+<br> Mistral-Medium-3.1 2508+<br> Mistral-Small-3.2 2506+<br> Mistral-Small-4<br> 
 | gemma4         |                                              | `<\|channel>thought` `<channel\|>`         | Gemma 4-it
@@ -56,6 +57,11 @@ in the model config (e.g. in the model folder's `tabby_config.yml`).
 (boolean, or the equivalent `thinking_mode: chat|thinking`) and `reasoning_effort` (`low`,
 `high`, `max`; `low` is the default and `high`/`max` prepend effort prompts to the context) as
 template variables, settable per request via the top-level fields or `chat_template_kwargs`.
+
+**⁵** LFM2 models emit a Pythonic tool-call list in `<|tool_call_start|>[...]<|tool_call_end|>`,
+which the server's bundled template doesn't explicitly steer the model toward. Point the model at
+the included `templates/lfm2.jinja` (`prompt_template: lfm2.jinja`) so fresh-session tool calls
+reliably use that format instead of drifting to OpenAI-style JSON.
 The template requires parallel tool results in the same order as the corresponding tool calls;
 TabbyAPI sorts tool messages by `tool_call_id` before templating, so clients may send them in
 any order.

--- a/endpoints/OAI/utils/toolcall_formats/lfm2.py
+++ b/endpoints/OAI/utils/toolcall_formats/lfm2.py
@@ -1,0 +1,167 @@
+import ast
+import json
+import keyword
+import re
+
+from common.logger import xlogger
+from endpoints.OAI.types.tools import ToolCall, Tool
+
+"""
+LFM2 / LFM2.5 (Liquid AI) - Pythonic tool-call list
+
+LFM2-family models natively emit a Pythonic call list rather than
+OpenAI-style JSON, wrapped in <|tool_call_start|> / <|tool_call_end|>
+sentinels. The argument values are real Python literals.
+
+Raw format:
+    <|tool_call_start|>[get_weather(location='Paris', days=3)]<|tool_call_end|>
+
+Parallel calls appear as multiple calls in the list:
+    <|tool_call_start|>[f(a=1), g(b='x')]<|tool_call_end|>
+
+Each call becomes a ToolCall whose name is the called function and whose
+arguments are the (JSON-encoded) keyword arguments.
+"""
+
+TOOLCALL_START = "<|tool_call_start|>"
+TOOLCALL_END = "<|tool_call_end|>"
+
+# Python reserved words that are illegal as keyword-argument names in a
+# literal call list (e.g. from=...). They are renamed during parsing and
+# restored afterwards.
+_RESERVED = set(keyword.kwlist)
+
+# Double- or single-quoted string literal (with backslash escapes).
+_STR_RE = re.compile(r"'(?:[^'\\]|\\.)*'|\"(?:[^\"\\]|\\.)*\"")
+
+# A reserved word used as a keyword-argument name: identifier followed by '='.
+_RESERVED_KW_RE = re.compile(rf"\b({'|'.join(sorted(_RESERVED))})\s*(?==)")
+
+# Leading-zero integer literal (e.g. 07 -> 7), invalid in Python 3.
+_LEAD_ZERO_RE = re.compile(r"(?<![\w.])0(\d+)")
+
+
+def _extract_tool_texts(text: str) -> list[str]:
+    """Extract the Pythonic call-list text between sentinel tokens.
+
+    Every <|tool_call_start|>...<|tool_call_end|> span is collected. An
+    unterminated start token yields the text from it to the end (stream may
+    have been cut off). If no start token appears at all, the whole input is
+    treated as a call list so callers that strip sentinels themselves still
+    work.
+    """
+    texts = []
+    idx = 0
+    while True:
+        start = text.find(TOOLCALL_START, idx)
+        if start == -1:
+            break
+        end = text.find(TOOLCALL_END, start)
+        if end == -1:
+            texts.append(text[start + len(TOOLCALL_START) :].strip())
+            break
+        texts.append(text[start + len(TOOLCALL_START) : end].strip())
+        idx = end + len(TOOLCALL_END)
+
+    if not texts:
+        texts = [text.strip()]
+    return texts
+
+
+def _protect_strings(text: str) -> tuple[str, list[str]]:
+    """Mask string literals so keyword/leading-zero rewrites never touch
+    their contents, returning (masked_text, literals)."""
+    literals = []
+
+    def repl(match):
+        literals.append(match.group(0))
+        return f"@@S{len(literals) - 1}@@"
+
+    return _STR_RE.sub(repl, text), literals
+
+
+def _restore_strings(text: str, literals: list[str]) -> str:
+    for i, lit in enumerate(literals):
+        text = text.replace(f"@@S{i}@@", lit)
+    return text
+
+
+def _safe_parse_list(text: str) -> tuple:
+    """Parse the Pythonic call list, applying progressive rewrites for text
+    that is valid Pythonic-but-not-quite-Python. On success returns
+    (module, reserved_kw_map); on failure (None, {}).
+
+    The rewrites (renaming reserved-word keyword args, normalizing
+    leading-zero ints) are deterministic, so repeated streaming chunks stay
+    consistent — though in this server tool blocks are parsed once at the
+    end of the stream, so that isn't relied upon here.
+    """
+    try:
+        return ast.parse(text), {}
+    except (SyntaxError, ValueError):
+        pass
+
+    # Fallback path: protect strings, then rewrite reserved keywords and
+    # leading-zero ints independently, then restore strings and re-parse.
+    protected, literals = _protect_strings(text)
+    reserved_map = {}
+
+    def _reserved_repl(match):
+        original = match.group(1)
+        placeholder = f"__lfmkw{len(reserved_map)}__"
+        reserved_map[placeholder] = original
+        return placeholder
+
+    renamed = _RESERVED_KW_RE.sub(_reserved_repl, protected)
+    normalized = _LEAD_ZERO_RE.sub(r"\1", renamed)
+    restored = _restore_strings(normalized, literals)
+
+    try:
+        return ast.parse(restored), reserved_map
+    except (SyntaxError, ValueError):
+        return None, {}
+
+
+def _call_to_toolcall(call: ast.Call, reserved_map: dict) -> ToolCall:
+    """Convert a parsed ast.Call into a ToolCall with JSON arguments."""
+    # Function name — plain names and dotted paths (os.path.join) both work.
+    name = ast.unparse(call.func)
+
+    args: dict = {}
+    for kw in call.keywords:
+        key = kw.arg
+        if key in reserved_map:
+            key = reserved_map[key]
+        try:
+            args[key] = ast.literal_eval(kw.value)
+        except (ValueError, SyntaxError):
+            # Unrenderable literal — fall back to its textual form
+            args[key] = ast.unparse(kw.value)
+
+    return ToolCall(function=Tool(name=name, arguments=json.dumps(args, ensure_ascii=False)))
+
+
+def parse_toolcalls(text: str) -> list[ToolCall]:
+    results = []
+
+    for block in _extract_tool_texts(text):
+        module, reserved_map = _safe_parse_list(block)
+        if module is None:
+            continue
+
+        node = getattr(module.body[0], "value", None)
+        # An empty list ([]) is a deliberate no-op, not a tool call.
+        if not (
+            isinstance(node, ast.List)
+            and node.elts
+            and all(isinstance(e, ast.Call) for e in node.elts)
+        ):
+            continue
+
+        results.extend(_call_to_toolcall(e, reserved_map) for e in node.elts)
+
+    xlogger.debug(
+        f"lfm2: Parsed {len(results)} tool calls",
+        {"raw_text": text, "results": results},
+    )
+    return results

--- a/endpoints/OAI/utils/tools.py
+++ b/endpoints/OAI/utils/tools.py
@@ -15,6 +15,7 @@ from endpoints.OAI.utils.toolcall_formats import (
     mistral_old,
     mistral,
     gemma4,
+    lfm2,
 )
 
 ALL_TOOLCALL_FORMATS = {
@@ -29,6 +30,9 @@ ALL_TOOLCALL_FORMATS = {
     "hy_v3": hy3,
     "laguna": glm4_5,
     "poolside_v1": glm4_5,
+    "lfm": lfm2,
+    "lfm2": lfm2,
+    "lfm2_5": lfm2,
     "minimax_m2": minimax_m2,
     "minimax_m2_1": minimax_m2,
     "minimax_m2_5": minimax_m2,

--- a/templates/lfm2.jinja
+++ b/templates/lfm2.jinja
@@ -1,0 +1,114 @@
+{# lfm2.jinja — chat template for LFM2 / LFM2.5 (Liquid AI), for tabbyAPI.
+# Based on the model's stock chat_template.jinja, with two serving fixes:
+#   1) an explicit tool-CALL output-format directive in the system block
+#      (the stock template lists tools but never says how to emit a call,
+#      which made fresh-session calls drift toward OpenAI-style JSON),
+#   2) escaping of quotes/backslashes in string args when rendering assistant
+#      tool-call history into the pythonic <|tool_call_start|>[...]<|tool_call_end|> list.
+# Select via model config:  prompt_template: lfm2.jinja
+#}
+{{- bos_token -}}
+{%- set preserve_thinking = preserve_thinking | default(false) -%}
+
+{%- macro format_arg_value(arg_value) -%}
+    {%- if arg_value is string -%}
+        {{- "'" + (arg_value | replace("\\", "\\\\") | replace("'", "\\'")) + "'" -}}
+    {%- elif arg_value is mapping -%}
+        {{- arg_value | tojson -}}
+    {%- else -%}
+        {{- arg_value | string -}}
+    {%- endif -%}
+{%- endmacro -%}
+
+{%- macro parse_content(content) -%}
+    {%- if content is string -%}
+        {{- content -}}
+    {%- else -%}
+        {%- set _ns = namespace(result="") -%}
+        {%- for item in content -%}
+            {%- if item["type"] == "image" -%}
+                {%- set _ns.result = _ns.result + "<image>" -%}
+            {%- elif item["type"] == "text" -%}
+                {%- set _ns.result = _ns.result + item["text"] -%}
+            {%- else -%}
+                {%- set _ns.result = _ns.result + item | tojson -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {{- _ns.result -}}
+    {%- endif -%}
+{%- endmacro -%}
+
+{%- macro render_tool_calls(tool_calls) -%}
+    {%- set tool_calls_ns = namespace(tool_calls=[]) -%}
+    {%- for tool_call in tool_calls -%}
+        {%- set func_name = tool_call["function"]["name"] -%}
+        {%- set func_args = tool_call["function"]["arguments"] -%}
+        {%- set args_ns = namespace(arg_strings=[]) -%}
+        {%- for arg_name, arg_value in func_args.items() -%}
+            {%- set args_ns.arg_strings = args_ns.arg_strings + [arg_name + "=" + format_arg_value(arg_value)] -%}
+        {%- endfor -%}
+        {%- set tool_calls_ns.tool_calls = tool_calls_ns.tool_calls + [func_name + "(" + (args_ns.arg_strings | join(", ")) + ")"] -%}
+    {%- endfor -%}
+    {{- "<|tool_call_start|>[" + (tool_calls_ns.tool_calls | join(", ")) + "]<|tool_call_end|>" -}}
+{%- endmacro -%}
+
+{%- set ns = namespace(system_prompt="", last_user_index=-1) -%}
+{%- if messages[0]["role"] == "system" -%}
+    {%- if messages[0].get("content") -%}
+        {%- set ns.system_prompt = parse_content(messages[0]["content"]) -%}
+    {%- endif -%}
+    {%- set messages = messages[1:] -%}
+{%- endif -%}
+{%- if tools -%}
+    {%- set ns.system_prompt = ns.system_prompt + ("\n\n" if ns.system_prompt else "") + "Today's date: " + strftime_now("%Y-%m-%d") + "\n\nList of tools: " + (tools | tojson) + "\n\nTo call a tool, output EXACTLY one line wrapped in <|tool_call_start|> and <|tool_call_end|>: [function_name(arg=value, arg2=123)]. Never emit JSON. If no tool is needed, answer in prose." -%}
+{%- endif -%}
+{%- if ns.system_prompt -%}
+    {{- "<|im_start|>system\n" + ns.system_prompt + "<|im_end|>\n" -}}
+{%- endif -%}
+{%- for message in messages -%}
+    {%- if message["role"] == "user" -%}
+        {%- set ns.last_user_index = loop.index0 -%}
+    {%- endif -%}
+{%- endfor -%}
+{%- for message in messages -%}
+    {{- "<|im_start|>" + message.role + "\n" -}}
+    {%- if message.role == "assistant" -%}
+        {%- generation -%}
+        {%- if message.thinking is defined and (preserve_thinking or loop.index0 > ns.last_user_index) -%}
+            {{- "<think>" + message.thinking + "</think>" -}}
+        {%- endif -%}
+        {%- set _cfm_tag = "CONTINUE_FINAL_MESSAGE_TAG " -%}
+        {%- set _has_cfm = false -%}
+        {%- if message.content is defined -%}
+            {%- set content = parse_content(message.content) -%}
+            {%- if not (preserve_thinking or loop.index0 > ns.last_user_index) -%}
+                {%- if "</think>" in content -%}
+                    {%- set content = content.split("</think>")[-1] | trim -%}
+                {%- endif -%}
+            {%- endif -%}
+            {%- if message.tool_calls is defined and content.endswith(_cfm_tag) -%}
+                {%- set _has_cfm = true -%}
+                {%- set _trunc_len = (content | length) - (_cfm_tag | length) -%}
+                {{- content[:_trunc_len] -}}
+            {%- else -%}
+                {{- content -}}
+            {%- endif -%}
+        {%- endif -%}
+        {%- if message.tool_calls is defined -%}
+            {{- render_tool_calls(message.tool_calls) -}}
+        {%- endif -%}
+        {%- if _has_cfm -%}
+            {{- _cfm_tag -}}
+        {%- endif -%}
+        {{- "<|im_end|>\n" -}}
+        {%- endgeneration -%}
+    {%- else %}
+        {%- if message.get("content") -%}
+            {{- parse_content(message["content"]) -}}
+        {%- endif -%}
+        {{- "<|im_end|>\n" -}}
+    {%- endif %}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    {{- "<|im_start|>assistant\n" -}}
+{%- endif -%}

--- a/tests/test_stream_parser.py
+++ b/tests/test_stream_parser.py
@@ -767,5 +767,132 @@ class DeepseekV4ToolcallFormatTests(unittest.TestCase):
         self.assertEqual(calls[0].function.arguments, '{"location": "Tokyo"}')
 
 
+class Lfm2ToolcallFormatTests(unittest.TestCase):
+    """
+    LFM2 / LFM2.5 models emit a Pythonic tool-call list wrapped in
+    <|tool_call_start|> and <|tool_call_end|> sentinels, e.g.
+        <|tool_call_start|>[browser_navigate(url='/home/user1/workspace')]<|tool_call_end|>
+    The parser turns each function call in the list into a ToolCall with
+    JSON-encoded keyword arguments.
+    """
+
+    def parse(self, text):
+        from endpoints.OAI.utils.toolcall_formats.lfm2 import parse_toolcalls
+
+        return parse_toolcalls(text)
+
+    def test_single_call(self):
+        calls = self.parse(
+            "<|tool_call_start|>"
+            "[browser_navigate(url='/home/user1/workspace')]"
+            "<|tool_call_end|>"
+        )
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].function.name, "browser_navigate")
+        self.assertEqual(
+            calls[0].function.arguments, '{"url": "/home/user1/workspace"}'
+        )
+
+    def test_parallel_calls(self):
+        calls = self.parse(
+            "<|tool_call_start|>"
+            '[f(a=1), g(b="x")]'
+            "<|tool_call_end|>"
+        )
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[0].function.name, "f")
+        self.assertEqual(calls[0].function.arguments, '{"a": 1}')
+        self.assertEqual(calls[1].function.name, "g")
+        self.assertEqual(calls[1].function.arguments, '{"b": "x"}')
+
+    def test_typed_kwargs(self):
+        calls = self.parse(
+            "<|tool_call_start|>"
+            "[f(count=3, ratio=0.5, ok=True, nothing=None, "
+            'items=["x", "y"], obj={"k": 1}, neg=-2)]'
+            "<|tool_call_end|>"
+        )
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(
+            calls[0].function.arguments,
+            '{"count": 3, "ratio": 0.5, "ok": true, "nothing": null, '
+            '"items": ["x", "y"], "obj": {"k": 1}, "neg": -2}',
+        )
+
+    def test_nested_quotes(self):
+        # Single-quoted value containing an escaped double quote and a colon
+        calls = self.parse(
+            "<|tool_call_start|>"
+            '[f(command="echo \\"hi\\"")]'
+            "<|tool_call_end|>"
+        )
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(
+            calls[0].function.arguments, r'{"command": "echo \"hi\""}'
+        )
+
+    def test_no_args(self):
+        calls = self.parse("<|tool_call_start|>[list_files()]<|tool_call_end|>")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].function.name, "list_files")
+        self.assertEqual(calls[0].function.arguments, "{}")
+
+    def test_empty_list_no_calls(self):
+        calls = self.parse("<|tool_call_start|>[]<|tool_call_end|>")
+        self.assertEqual(len(calls), 0)
+
+    def test_parses_without_sentinels(self):
+        # No sentinels present — treat the whole text as the call list
+        calls = self.parse("[f(a=1)]")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].function.name, "f")
+        self.assertEqual(calls[0].function.arguments, '{"a": 1}')
+
+    def test_plain_prose_returns_nothing(self):
+        calls = self.parse("No tool calls here. The weather is nice.")
+        self.assertEqual(len(calls), 0)
+
+    def test_malformed_returns_nothing(self):
+        calls = self.parse("<|tool_call_start|>greetings, world<|tool_call_end|>")
+        self.assertEqual(len(calls), 0)
+
+    def test_reserved_keyword_param(self):
+        # A tool parameter named after a Python keyword cannot be parsed as
+        # a literal; it must be rewritten and restored.
+        calls = self.parse("<|tool_call_start|>[f(from='x')]<|tool_call_end|>")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].function.name, "f")
+        self.assertEqual(calls[0].function.arguments, '{"from": "x"}')
+
+    def test_streamed_through_tag_parser(self):
+        from endpoints.OAI.utils.toolcall_formats.lfm2 import (
+            TOOLCALL_START,
+            TOOLCALL_END,
+        )
+
+        p = TagStreamParser(
+            reasoning_start="<|thinking|>",
+            reasoning_end="</thinking>",
+            tool_start=TOOLCALL_START,
+            tool_end=TOOLCALL_END,
+            start_in_reasoning=True,
+        )
+        text = (
+            "pondering</thinking>Let me check."
+            "<|tool_call_start|>"
+            "[get_weather(location='Tokyo')]"
+            "<|tool_call_end|>"
+        )
+        # Feed in small chunks to exercise tag holdback
+        out = collect(p, [text[i : i + 7] for i in range(0, len(text), 7)])
+        self.assertEqual(out["reasoning"], "pondering")
+        self.assertEqual(out["content"], "Let me check.")
+
+        calls = self.parse(out["tool"])
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0].function.name, "get_weather")
+        self.assertEqual(calls[0].function.arguments, '{"location": "Tokyo"}')
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Problem: LFM2 / LFM2.5 (Liquid AI) models emit tool calls as a Pythonic list wrapped in
 <|tool_call_start|>[...]<|tool_call_end|> sentinels, not OpenAI-style JSON. Generic parsers misread this, so tool
 calls appear broken whenever an agent is swapped onto an LFM.

 Why add it: enables the LFM2 family for agents/tool-calling, mirroring vllm's lfm2 tool parser. Includes
 templates/lfm2.jinja which steers fresh-session calls toward the sentinel format (the stock template lists tools but
 never says how to emit a call, so output drifted to JSON).

 Examples: raw model output

 ```
   <|tool_call_start|>[browser_navigate(url='/home/user1/workspace')]<|tool_call_end|>
 ```

 parses to

 ```
   {"function": {"name": "browser_navigate", "arguments": "{\"url\": \"/home/user1/workspace\"}"}}
 ```

 Validated against a live lfm2.5 server: non-streaming, streaming, parallel calls (index 0/1), and content-only
 responses (no false positives). Registered as tool_format: lfm2 | lfm | lfm2_5.

 Additional context: new module endpoints/OAI/utils/toolcall_formats/lfm2.py (ast-based, handles reserved-keyword
 params and leading-zero ints), registration in tools.py, 11 tests in test_stream_parser.py, docs row/footnote,
 .gitignore tunes to ship the template.
